### PR TITLE
Add GLM API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ https://github.com/user-attachments/assets/demo.mp4
 - **Google Gemini** — Fast, generous free tier
 - **OpenAI GPT-4o** — Industry standard
 - **Anthropic Claude** — Best for reasoning
+- **Z AI GLM** — Chinese optimized, multimodal support
 - **Ollama** — 100% local, fully private
 
 </td>
@@ -151,6 +152,7 @@ https://github.com/user-attachments/assets/demo.mp4
 | **Google Gemini** | [aistudio.google.com](https://aistudio.google.com/apikey) | ⭐ **Recommended** — Free tier |
 | **OpenAI** | [platform.openai.com](https://platform.openai.com/api-keys) | Requires payment |
 | **Anthropic** | [console.anthropic.com](https://console.anthropic.com/) | Requires payment |
+| **Z AI** | [api.z.ai](https://api.z.ai/) | Supports GLM-4.5, GLM-4.6, GLM-4.7 |
 | **Ollama** | [ollama.ai](https://ollama.ai) | Local install, no API key needed |
 
 ---
@@ -211,7 +213,7 @@ omnirecall/
 
 ## 🗺️ Roadmap
 
-- [x] Multi-provider AI (Gemini, OpenAI, Claude, Ollama)
+- [x] Multi-provider AI (Gemini, OpenAI, Claude, GLM, Ollama)
 - [x] Document RAG with persistent storage
 - [x] Streaming responses
 - [x] Markdown rendering with code blocks

--- a/src-tauri/src/commands/providers.rs
+++ b/src-tauri/src/commands/providers.rs
@@ -37,6 +37,17 @@ pub async fn get_providers() -> Result<Vec<serde_json::Value>> {
             "models": ["claude-3-5-sonnet-20241022", "claude-3-5-haiku-20241022"],
         }),
         serde_json::json!({
+            "id": "glm",
+            "name": "Z AI GLM",
+            "models": [
+                "glm-4.7",
+                "glm-4.6",
+                "glm-4.5",
+                "glm-4.5-air",
+                "glm-4.5-flash"
+            ],
+        }),
+        serde_json::json!({
             "id": "ollama",
             "name": "Ollama (Local)",
             "models": ["llama3.2", "mistral", "codellama"],

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -158,6 +158,7 @@ function ProviderCardCompact({ provider }: { provider: any }) {
       gemini: "https://aistudio.google.com/apikey",
       openai: "https://platform.openai.com/api-keys",
       anthropic: "https://console.anthropic.com/",
+      glm: "https://api.z.ai/",
       ollama: "https://ollama.ai",
     };
     return urls[provider.id];
@@ -332,6 +333,7 @@ function ProviderCard({ provider }: { provider: any }) {
       gemini: "https://aistudio.google.com/apikey",
       openai: "https://platform.openai.com/api-keys",
       anthropic: "https://console.anthropic.com/",
+      glm: "https://api.z.ai/",
       ollama: "https://ollama.ai",
     };
     return urls[provider.id];

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -73,6 +73,19 @@ export const providers = signal<AIProvider[]>([
     isConnected: false,
   },
   {
+    id: "glm",
+    name: "Z AI GLM",
+    models: [
+      "glm-4.7",
+      "glm-4.6",
+      "glm-4.5",
+      "glm-4.5-air",
+      "glm-4.5-flash",
+    ],
+    apiKey: "",
+    isConnected: false,
+  },
+  {
     id: "ollama",
     name: "Ollama (Local)",
     models: ["llama3.2", "mistral", "codellama", "gemma3:1b", "qwen3-vl:8b", "qwen3-vl:4b"],


### PR DESCRIPTION
### Changes
- Added GLM API support using `https://api.z.ai/api/paas/v4` endpoint
- Added `test_glm()` function for API key validation
- Added `chat_glm_with_history()` for chat completions
- Added `stream_glm_with_emitter()` for streaming responses
- Updated model lists to include `glm-4.7`, `glm-4.6`, `glm-4.5`, `glm-4.5-air`, `glm-4.5-flash`
- Updated documentation (README.md) with Z.AI API reference

###  Testing
- Tested with valid Z.AI API key
- All API calls working correctly (test, chat, stream)
- Rust code compiles successfully
- Frontend builds successfully

### References
- Z.AI docs: https://docs.z.ai/api-reference/llm/chat-completion