### PR TITLE
ci: add auto-version-bump to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,40 +10,81 @@ permissions:
   contents: write
 
 jobs:
-  # First: check if this version already has a release (cheap, runs on ubuntu)
-  check-version:
+  # ─── Job 1: Version check + auto-bump ──────────────────────────
+  check-and-bump:
     runs-on: ubuntu-latest
     outputs:
-      should_release: ${{ steps.check.outputs.should_release }}
-      version: ${{ steps.check.outputs.version }}
+      should_release: ${{ steps.bump.outputs.should_release }}
+      version: ${{ steps.bump.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Check if version tag exists
-        id: check
+      - name: Check for changes and bump version
+        id: bump
         run: |
-          VERSION=$(jq -r '.version' src-tauri/tauri.conf.json)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          if git tag -l "v$VERSION" | grep -q "v$VERSION"; then
-            echo "should_release=false" >> $GITHUB_OUTPUT
-            echo "::notice::Tag v$VERSION already exists — skipping release"
-          else
+          # Get current version from tauri.conf.json
+          CURRENT_VERSION=$(jq -r '.version' src-tauri/tauri.conf.json)
+          echo "Current version: $CURRENT_VERSION"
+
+          # Check if tag for current version exists
+          if git tag -l "v$CURRENT_VERSION" | grep -q "v$CURRENT_VERSION"; then
+            echo "Tag v$CURRENT_VERSION already exists"
+
+            # Check if there are commits since the last tag
+            COMMITS_SINCE=$(git rev-list "v$CURRENT_VERSION"..HEAD --count 2>/dev/null || echo "0")
+            echo "Commits since v$CURRENT_VERSION: $COMMITS_SINCE"
+
+            if [ "$COMMITS_SINCE" -eq "0" ]; then
+              echo "No new commits since last release — skipping"
+              echo "should_release=false" >> $GITHUB_OUTPUT
+              echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+
+            # Auto-bump patch version
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+            NEW_PATCH=$((PATCH + 1))
+            NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH"
+            echo "Bumping version: $CURRENT_VERSION → $NEW_VERSION"
+
+            # Update tauri.conf.json
+            jq --arg v "$NEW_VERSION" '.version = $v' src-tauri/tauri.conf.json > tmp.json && mv tmp.json src-tauri/tauri.conf.json
+
+            # Update package.json
+            jq --arg v "$NEW_VERSION" '.version = $v' package.json > tmp.json && mv tmp.json package.json
+
+            # Update Cargo.toml version
+            sed -i "s/^version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/" src-tauri/Cargo.toml
+
+            # Commit the version bump
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add src-tauri/tauri.conf.json package.json src-tauri/Cargo.toml
+            git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
+            git push
+
             echo "should_release=true" >> $GITHUB_OUTPUT
-            echo "::notice::New version v$VERSION detected — will build and release"
+            echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "Tag v$CURRENT_VERSION does not exist — first release"
+            echo "should_release=true" >> $GITHUB_OUTPUT
+            echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
           fi
 
-  # Second: build and release only if version is new
+  # ─── Job 2: Build + Release ────────────────────────────────
   release:
-    needs: check-version
-    if: needs.check-version.outputs.should_release == 'true'
+    needs: check-and-bump
+    if: needs.check-and-bump.outputs.should_release == 'true'
     runs-on: windows-latest
 
     steps:
-      - name: Checkout repository
+      - name: Checkout repository (with bumped version)
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Upgrade release workflow from simple tag-check to full auto-versioning:
- Auto-detect new commits since last tagged release
- Auto-bump patch version across tauri.conf.json, package.json, Cargo.toml
- Commit version bump with [skip ci] to prevent infinite loops
- Skip release when no new commits exist since last tag
- Checkout with ref:main in build job to pick up bumped version
