### PR TITLE
Security, persistence, and a11y improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omnirecall",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omnirecall",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "dependencies": {
         "@preact/signals": "^1.2.2",
         "@tauri-apps/api": "^2.0.0",
@@ -941,9 +941,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
-      "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
       "cpu": [
         "arm"
       ],
@@ -955,9 +955,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
-      "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
       "cpu": [
         "arm64"
       ],
@@ -969,9 +969,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
-      "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
       "cpu": [
         "arm64"
       ],
@@ -983,9 +983,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
-      "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
       "cpu": [
         "x64"
       ],
@@ -997,9 +997,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
-      "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
       "cpu": [
         "arm64"
       ],
@@ -1011,9 +1011,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
-      "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
       "cpu": [
         "x64"
       ],
@@ -1025,9 +1025,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
-      "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
       "cpu": [
         "arm"
       ],
@@ -1039,9 +1039,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
-      "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
       "cpu": [
         "arm"
       ],
@@ -1053,9 +1053,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
-      "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
       "cpu": [
         "arm64"
       ],
@@ -1067,9 +1067,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
-      "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
       "cpu": [
         "arm64"
       ],
@@ -1081,9 +1081,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
-      "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
       "cpu": [
         "loong64"
       ],
@@ -1095,9 +1109,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
-      "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
       "cpu": [
         "ppc64"
       ],
@@ -1109,9 +1137,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
-      "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
       "cpu": [
         "riscv64"
       ],
@@ -1123,9 +1151,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
-      "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1137,9 +1165,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
-      "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
       "cpu": [
         "s390x"
       ],
@@ -1151,9 +1179,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
-      "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
       "cpu": [
         "x64"
       ],
@@ -1165,9 +1193,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
-      "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
       "cpu": [
         "x64"
       ],
@@ -1178,10 +1206,24 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
-      "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
       "cpu": [
         "arm64"
       ],
@@ -1193,9 +1235,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
-      "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
       "cpu": [
         "arm64"
       ],
@@ -1207,9 +1249,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
-      "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
       "cpu": [
         "ia32"
       ],
@@ -1221,9 +1263,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
-      "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
       "cpu": [
         "x64"
       ],
@@ -1235,9 +1277,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
-      "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
       "cpu": [
         "x64"
       ],
@@ -2437,9 +2479,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2470,9 +2512,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -2634,9 +2676,9 @@
       "license": "MIT"
     },
     "node_modules/preact": {
-      "version": "10.27.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz",
-      "integrity": "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==",
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -2721,9 +2763,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.53.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
-      "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2737,28 +2779,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.53.3",
-        "@rollup/rollup-android-arm64": "4.53.3",
-        "@rollup/rollup-darwin-arm64": "4.53.3",
-        "@rollup/rollup-darwin-x64": "4.53.3",
-        "@rollup/rollup-freebsd-arm64": "4.53.3",
-        "@rollup/rollup-freebsd-x64": "4.53.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
-        "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
-        "@rollup/rollup-linux-arm64-gnu": "4.53.3",
-        "@rollup/rollup-linux-arm64-musl": "4.53.3",
-        "@rollup/rollup-linux-loong64-gnu": "4.53.3",
-        "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
-        "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
-        "@rollup/rollup-linux-riscv64-musl": "4.53.3",
-        "@rollup/rollup-linux-s390x-gnu": "4.53.3",
-        "@rollup/rollup-linux-x64-gnu": "4.53.3",
-        "@rollup/rollup-linux-x64-musl": "4.53.3",
-        "@rollup/rollup-openharmony-arm64": "4.53.3",
-        "@rollup/rollup-win32-arm64-msvc": "4.53.3",
-        "@rollup/rollup-win32-ia32-msvc": "4.53.3",
-        "@rollup/rollup-win32-x64-gnu": "4.53.3",
-        "@rollup/rollup-win32-x64-msvc": "4.53.3",
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
         "fsevents": "~2.3.2"
       }
     },
@@ -2969,9 +3014,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1,7 +1,14 @@
-use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Emitter};
+use serde::Deserialize;
+use std::sync::atomic::{AtomicBool, Ordering};
+use tauri::AppHandle;
 use crate::error::Result;
 use crate::services::ai_client::AiClient;
+
+/// Global cancellation flag for in-flight streaming requests.
+/// Streaming chat is sequential (compare mode runs models one-by-one), so a
+/// single flag is sufficient. Set to true by the `stop_generation` command and
+/// reset to false at the start of each new stream.
+pub(crate) static STREAM_CANCELLED: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Deserialize)]
 pub struct ChatMessage {
@@ -15,10 +22,15 @@ pub struct DocumentContext {
     pub content: String,
 }
 
-#[derive(Clone, Serialize)]
-pub struct StreamChunk {
-    pub chunk: String,
-    pub done: bool,
+fn build_doc_context(documents: &[DocumentContext]) -> Option<String> {
+    if documents.is_empty() {
+        return None;
+    }
+    let mut context = String::from("Use the following document context to answer the question:\n\n");
+    for doc in documents {
+        context.push_str(&format!("--- Document: {} ---\n{}\n\n", doc.name, doc.content));
+    }
+    Some(context)
 }
 
 #[tauri::command]
@@ -31,20 +43,10 @@ pub async fn send_message(
     api_key: String,
 ) -> Result<String> {
     let client = AiClient::new(&provider, &api_key, None);
-    
-    // Build context from documents
-    let doc_context = if !documents.is_empty() {
-        let mut context = String::from("Use the following document context to answer the question:\n\n");
-        for doc in &documents {
-            context.push_str(&format!("--- Document: {} ---\n{}\n\n", doc.name, doc.content));
-        }
-        Some(context)
-    } else {
-        None
-    };
-    
-    // Send with history and context
-    let response = client.chat_with_history(&model, &message, &history, doc_context.as_deref()).await?;
+    let doc_context = build_doc_context(&documents);
+    let response = client
+        .chat_with_history(&model, &message, &history, doc_context.as_deref())
+        .await?;
     Ok(response)
 }
 
@@ -59,20 +61,12 @@ pub async fn send_message_stream(
     model: String,
     api_key: String,
 ) -> Result<()> {
+    // Reset cancellation flag for this new stream
+    STREAM_CANCELLED.store(false, Ordering::SeqCst);
+
     let client = AiClient::new(&provider, &api_key, None);
-    
-    // Build context from documents
-    let doc_context = if !documents.is_empty() {
-        let mut context = String::from("Use the following document context to answer the question:\n\n");
-        for doc in &documents {
-            context.push_str(&format!("--- Document: {} ---\n{}\n\n", doc.name, doc.content));
-        }
-        Some(context)
-    } else {
-        None
-    };
-    
-    // Stream response - pass app handle for event emission
+    let doc_context = build_doc_context(&documents);
+
     client.chat_stream_with_emitter(
         &app,
         &model,
@@ -80,11 +74,13 @@ pub async fn send_message_stream(
         &history,
         doc_context.as_deref(),
     ).await?;
-    
+
     Ok(())
 }
 
+/// Signal in-flight streaming requests to abort.
 #[tauri::command]
-pub async fn stop_generation(_stream_id: String) -> Result<()> {
+pub async fn stop_generation() -> Result<()> {
+    STREAM_CANCELLED.store(true, Ordering::SeqCst);
     Ok(())
 }

--- a/src-tauri/src/commands/documents.rs
+++ b/src-tauri/src/commands/documents.rs
@@ -16,6 +16,7 @@ pub struct Document {
 
 #[derive(Debug, Deserialize)]
 pub struct AddDocumentsRequest {
+    #[allow(dead_code)]
     pub space_id: String,
     pub file_paths: Vec<String>,
 }
@@ -26,12 +27,6 @@ pub struct AddDocumentsResponse {
     pub errors: Vec<String>,
 }
 
-#[derive(Debug, Serialize)]
-pub struct DocumentContent {
-    pub id: String,
-    pub name: String,
-    pub content: String,
-}
 
 #[tauri::command]
 pub async fn add_documents(request: AddDocumentsRequest) -> Result<AddDocumentsResponse> {
@@ -84,12 +79,50 @@ pub async fn list_documents(_space_id: String) -> Result<Vec<Document>> {
     Ok(vec![])
 }
 
+/// Maximum file size we'll attempt to read (50 MB). Beyond this we refuse
+/// rather than risk OOM or extreme parse latency for poorly-formed input.
+const MAX_DOCUMENT_BYTES: u64 = 50 * 1024 * 1024;
+/// Allow-list of extensions whose content we'll read. Prevents accidental
+/// reads of unexpected binary types (e.g. exe, dll) and makes the surface
+/// callable from the frontend explicit.
+const ALLOWED_EXTENSIONS: &[&str] = &[
+    "pdf", "txt", "md", "rst", "html", "htm",
+    "py", "js", "ts", "tsx", "jsx", "rs", "java", "cpp", "c", "h", "hpp",
+    "go", "rb", "php", "swift", "kt", "cs", "json", "yaml", "yml", "toml",
+    "xml", "csv", "sh", "ps1", "sql", "log", "conf", "ini", "env",
+];
+
+fn is_allowed_extension(ext: &str) -> bool {
+    ALLOWED_EXTENSIONS.iter().any(|allowed| allowed.eq_ignore_ascii_case(ext))
+}
+
 #[tauri::command]
 pub async fn read_document_content(file_path: String) -> Result<String> {
+    // Reject obvious traversal patterns. We cannot meaningfully sandbox the
+    // filesystem here (the user's own dialog picks arbitrary absolute paths)
+    // but we can still refuse paths whose components include `..`, which are
+    // never produced by the dialog and only show up if a caller is trying to
+    // confuse path resolution downstream.
+    if file_path.split(['/', '\\']).any(|s| s == "..") {
+        return Err(AppError::File("Path traversal patterns are not allowed".to_string()));
+    }
+
     let path = Path::new(&file_path);
-    
+
     if !path.exists() {
         return Err(AppError::File(format!("File not found: {}", file_path)));
+    }
+
+    let metadata = fs::metadata(path).map_err(|e| AppError::File(e.to_string()))?;
+    if !metadata.is_file() {
+        return Err(AppError::File("Path is not a regular file".to_string()));
+    }
+    if metadata.len() > MAX_DOCUMENT_BYTES {
+        return Err(AppError::File(format!(
+            "File too large ({} MB). Maximum supported size is {} MB.",
+            metadata.len() / 1_048_576,
+            MAX_DOCUMENT_BYTES / 1_048_576,
+        )));
     }
 
     let extension = path.extension()
@@ -97,18 +130,21 @@ pub async fn read_document_content(file_path: String) -> Result<String> {
         .unwrap_or("")
         .to_lowercase();
 
+    if !is_allowed_extension(&extension) {
+        return Err(AppError::File(format!("Unsupported file type: .{}", extension)));
+    }
+
     let content = match extension.as_str() {
         "pdf" => extract_pdf_text(path)?,
-        "txt" | "md" | "py" | "js" | "ts" | "rs" | "java" | "cpp" | "c" | "h" | "json" | "yaml" | "yml" | "toml" => {
-            fs::read_to_string(path).map_err(|e| AppError::File(e.to_string()))?
-        }
         "html" | "htm" => {
             let html = fs::read_to_string(path).map_err(|e| AppError::File(e.to_string()))?;
             strip_html_tags(&html)
         }
         _ => {
-            // Try to read as text
-            fs::read_to_string(path).unwrap_or_else(|_| String::from("Unable to read file content"))
+            // Text-based formats. Use lossy UTF-8 for files that contain mixed
+            // encodings (e.g. log files) so we still surface readable content.
+            let bytes = fs::read(path).map_err(|e| AppError::File(e.to_string()))?;
+            String::from_utf8(bytes.clone()).unwrap_or_else(|_| String::from_utf8_lossy(&bytes).into_owned())
         }
     };
 
@@ -345,16 +381,15 @@ pub async fn get_relevant_context(
 /// Clear all indexed documents
 #[tauri::command]
 pub async fn clear_index() -> Result<()> {
-    use crate::services::vector_store::VectorStore;
     use directories::ProjectDirs;
-    
+
     if let Some(proj_dirs) = ProjectDirs::from("com", "omnirecall", "OmniRecall") {
         let db_path = proj_dirs.data_dir().join("vectors.db");
         if db_path.exists() {
             std::fs::remove_file(db_path)?;
         }
     }
-    
+
     Ok(())
 }
 

--- a/src-tauri/src/commands/providers.rs
+++ b/src-tauri/src/commands/providers.rs
@@ -7,6 +7,9 @@ pub async fn test_api_key(
     api_key: String,
     base_url: Option<String>,
 ) -> Result<()> {
+    if api_key.trim().is_empty() && provider != "ollama" {
+        return Err(crate::error::AppError::Config("API key is empty".to_string()));
+    }
     let client = AiClient::new(&provider, &api_key, base_url.as_deref());
     client.test_connection().await?;
     Ok(())
@@ -55,9 +58,3 @@ pub async fn get_providers() -> Result<Vec<serde_json::Value>> {
     ])
 }
 
-#[tauri::command]
-pub async fn save_api_key(_provider: String, _api_key: String) -> Result<()> {
-    // For now, we store in frontend state
-    // In production, use keyring crate for secure storage
-    Ok(())
-}

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,4 +1,3 @@
-use serde::{Deserialize, Serialize};
 use std::fs;
 use crate::config::{AppConfig, get_config_path};
 use crate::error::{AppError, Result};

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -39,10 +39,12 @@ pub fn get_config_path() -> PathBuf {
     get_data_dir().join("config.json")
 }
 
+#[allow(dead_code)]
 pub fn get_documents_dir() -> PathBuf {
     get_data_dir().join("documents")
 }
 
+#[allow(dead_code)]
 pub fn get_database_dir() -> PathBuf {
     get_data_dir().join("db")
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[allow(dead_code)] // RateLimited / Unknown are reserved for future use
 pub enum AppError {
     #[error("Network error: {0}")]
     Network(String),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,3 @@
-#![allow(dead_code)]
-#![allow(unused_imports)]
-
 mod commands;
 mod services;
 mod config;
@@ -216,7 +213,6 @@ pub fn run() {
             commands::chat::stop_generation,
             commands::providers::test_api_key,
             commands::providers::get_providers,
-            commands::providers::save_api_key,
             commands::documents::add_documents,
             commands::documents::remove_document,
             commands::documents::list_documents,

--- a/src-tauri/src/services/ai_client.rs
+++ b/src-tauri/src/services/ai_client.rs
@@ -1,13 +1,36 @@
+use std::sync::atomic::Ordering;
+use std::time::Duration;
 use reqwest::Client;
 use serde::Deserialize;
 use crate::error::{AppError, Result};
-use crate::commands::chat::ChatMessage;
+use crate::commands::chat::{ChatMessage, STREAM_CANCELLED};
+
+/// Connect timeout for all HTTP requests. Long-running streams have no
+/// overall request timeout (streams can legitimately run for minutes), but
+/// connection establishment must not hang.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+/// Whole-request timeout for non-streaming calls (test_connection, embeddings,
+/// non-streaming chat). Streaming calls override this with a connect-only
+/// budget so they can keep the response open.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+fn build_http_client(streaming: bool) -> Client {
+    let mut builder = Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        // Limit redirect chains to prevent open-redirect / SSRF amplification.
+        .redirect(reqwest::redirect::Policy::limited(3));
+    if !streaming {
+        builder = builder.timeout(REQUEST_TIMEOUT);
+    }
+    builder.build().unwrap_or_else(|_| Client::new())
+}
 
 pub struct AiClient {
     provider: String,
     api_key: String,
     base_url: Option<String>,
     client: Client,
+    streaming_client: Client,
 }
 
 impl AiClient {
@@ -16,8 +39,19 @@ impl AiClient {
             provider: provider.to_string(),
             api_key: api_key.to_string(),
             base_url: base_url.map(String::from),
-            client: Client::new(),
+            client: build_http_client(false),
+            streaming_client: build_http_client(true),
         }
+    }
+
+    /// Redact the API key from any string before it's surfaced to the user
+    /// or logged. Several providers put the key in the URL (Gemini) or the
+    /// Authorization header may be echoed in error envelopes.
+    fn redact(&self, msg: String) -> String {
+        if self.api_key.is_empty() || self.api_key.len() < 6 {
+            return msg;
+        }
+        msg.replace(&self.api_key, "[REDACTED]")
     }
 
     pub async fn test_connection(&self) -> Result<Vec<String>> {
@@ -29,10 +63,6 @@ impl AiClient {
             "glm" => self.test_glm().await,
             _ => Err(AppError::Config("Unknown provider".to_string())),
         }
-    }
-
-    pub async fn chat(&self, model: &str, message: &str) -> Result<String> {
-        self.chat_with_history(model, message, &[], None).await
     }
 
     pub async fn chat_with_history(
@@ -215,7 +245,7 @@ impl AiClient {
         if !response.status().is_success() {
             let status = response.status();
             let error_text = response.text().await.unwrap_or_default();
-            return Err(AppError::Api(format!("Gemini error {}: {}", status, error_text)));
+            return Err(AppError::Api(self.redact(format!("Gemini error {}: {}", status, error_text))));
         }
 
         let json: serde_json::Value = response.json().await?;
@@ -279,27 +309,32 @@ impl AiClient {
             }
         });
 
-        let response = self.client.post(&url)
+        let response = self.streaming_client.post(&url)
             .header("Content-Type", "application/json")
             .json(&body)
             .send()
-            .await?;
+            .await
+            .map_err(|e| AppError::Network(self.redact(e.to_string())))?;
 
         if !response.status().is_success() {
             let status = response.status();
             let error_text = response.text().await.unwrap_or_default();
-            return Err(AppError::Api(format!("Gemini stream error {}: {}", status, error_text)));
+            return Err(AppError::Api(self.redact(format!("Gemini stream error {}: {}", status, error_text))));
         }
 
         // Stream the response
         let mut stream = response.bytes_stream();
         let mut buffer = String::new();
-        
+
         while let Some(chunk_result) = stream.next().await {
-            let chunk = chunk_result.map_err(|e| AppError::Network(e.to_string()))?;
+            // Check if user requested cancellation - drop the connection.
+            if STREAM_CANCELLED.load(Ordering::SeqCst) {
+                break;
+            }
+            let chunk = chunk_result.map_err(|e| AppError::Network(self.redact(e.to_string())))?;
             let text = String::from_utf8_lossy(&chunk);
             buffer.push_str(&text);
-            
+
             // Process lines - SSE format uses "data: " prefix
             for line in buffer.lines().collect::<Vec<_>>() {
                 if let Some(data) = line.strip_prefix("data: ") {
@@ -313,13 +348,13 @@ impl AiClient {
                     }
                 }
             }
-            
+
             // Keep only incomplete line in buffer
             if let Some(last_newline) = buffer.rfind('\n') {
                 buffer = buffer[last_newline + 1..].to_string();
             }
         }
-        
+
         // Signal completion
         let _ = app.emit("chat-stream", serde_json::json!({
             "chunk": "",
@@ -369,7 +404,7 @@ impl AiClient {
         if !response.status().is_success() {
             let status = response.status();
             let error_text = response.text().await.unwrap_or_default();
-            return Err(AppError::Api(format!("OpenAI error {}: {}", status, error_text)));
+            return Err(AppError::Api(self.redact(format!("OpenAI error {}: {}", status, error_text))));
         }
 
         let json: serde_json::Value = response.json().await?;
@@ -416,7 +451,7 @@ impl AiClient {
         if !response.status().is_success() {
             let status = response.status();
             let error_text = response.text().await.unwrap_or_default();
-            return Err(AppError::Api(format!("Anthropic error {}: {}", status, error_text)));
+            return Err(AppError::Api(self.redact(format!("Anthropic error {}: {}", status, error_text))));
         }
 
         let json: serde_json::Value = response.json().await?;
@@ -468,7 +503,7 @@ impl AiClient {
         if !response.status().is_success() {
             let status = response.status();
             let error_text = response.text().await.unwrap_or_default();
-            return Err(AppError::Api(format!("Ollama error {}: {}", status, error_text)));
+            return Err(AppError::Api(self.redact(format!("Ollama error {}: {}", status, error_text))));
         }
 
         let json: serde_json::Value = response.json().await?;
@@ -520,7 +555,7 @@ impl AiClient {
         if !response.status().is_success() {
             let status = response.status();
             let error_text = response.text().await.unwrap_or_default();
-            return Err(AppError::Api(format!("GLM error {}: {}", status, error_text)));
+            return Err(AppError::Api(self.redact(format!("GLM error {}: {}", status, error_text))));
         }
 
         let json: serde_json::Value = response.json().await?;
@@ -567,17 +602,18 @@ impl AiClient {
             "stream": true,
         });
 
-        let response = self.client.post("https://api.z.ai/api/paas/v4/chat/completions")
+        let response = self.streaming_client.post("https://api.z.ai/api/paas/v4/chat/completions")
             .header("Authorization", format!("Bearer {}", self.api_key))
             .header("Content-Type", "application/json")
             .json(&body)
             .send()
-            .await?;
+            .await
+            .map_err(|e| AppError::Network(self.redact(e.to_string())))?;
 
         if !response.status().is_success() {
             let status = response.status();
             let error_text = response.text().await.unwrap_or_default();
-            return Err(AppError::Api(format!("GLM stream error {}: {}", status, error_text)));
+            return Err(AppError::Api(self.redact(format!("GLM stream error {}: {}", status, error_text))));
         }
 
         // Stream the response
@@ -585,7 +621,10 @@ impl AiClient {
         let mut buffer = String::new();
 
         while let Some(chunk_result) = stream.next().await {
-            let chunk = chunk_result.map_err(|e| AppError::Network(e.to_string()))?;
+            if STREAM_CANCELLED.load(Ordering::SeqCst) {
+                break;
+            }
+            let chunk = chunk_result.map_err(|e| AppError::Network(self.redact(e.to_string())))?;
             let text = String::from_utf8_lossy(&chunk);
             buffer.push_str(&text);
 

--- a/src-tauri/src/services/document_pipeline.rs
+++ b/src-tauri/src/services/document_pipeline.rs
@@ -1,6 +1,3 @@
-use std::path::Path;
-use crate::error::{AppError, Result};
-
 pub struct DocumentPipeline;
 
 #[derive(Debug, Clone)]
@@ -8,74 +5,11 @@ pub struct TextChunk {
     pub id: String,
     pub text: String,
     pub token_count: usize,
-    pub page_number: Option<u32>,
-    pub section_header: Option<String>,
 }
 
 impl DocumentPipeline {
     pub fn new() -> Self {
         Self
-    }
-
-    pub fn extract_text(&self, file_path: &Path) -> Result<String> {
-        let extension = file_path
-            .extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("")
-            .to_lowercase();
-
-        match extension.as_str() {
-            "pdf" => self.extract_pdf(file_path),
-            "txt" | "md" | "rst" => self.extract_text_file(file_path),
-            "py" | "js" | "ts" | "rs" | "java" | "cpp" | "c" | "go" | "rb" => {
-                self.extract_code_file(file_path)
-            }
-            "html" | "htm" => self.extract_html(file_path),
-            _ => Err(AppError::File(format!(
-                "Unsupported file type: {}",
-                extension
-            ))),
-        }
-    }
-
-    fn extract_pdf(&self, file_path: &Path) -> Result<String> {
-        let bytes = std::fs::read(file_path)?;
-        pdf_extract::extract_text_from_mem(&bytes)
-            .map_err(|e| AppError::File(format!("PDF extraction error: {}", e)))
-    }
-
-    fn extract_text_file(&self, file_path: &Path) -> Result<String> {
-        std::fs::read_to_string(file_path).map_err(|e| AppError::File(e.to_string()))
-    }
-
-    fn extract_code_file(&self, file_path: &Path) -> Result<String> {
-        let content = std::fs::read_to_string(file_path)?;
-        let extension = file_path
-            .extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("");
-        
-        // Add file metadata as header
-        Ok(format!(
-            "File: {}\nLanguage: {}\n\n{}",
-            file_path.file_name().unwrap_or_default().to_string_lossy(),
-            extension,
-            content
-        ))
-    }
-
-    fn extract_html(&self, file_path: &Path) -> Result<String> {
-        let content = std::fs::read_to_string(file_path)?;
-        // Simple HTML tag stripping (in production, use a proper HTML parser)
-        let text = content
-            .replace("<br>", "\n")
-            .replace("<br/>", "\n")
-            .replace("<p>", "\n")
-            .replace("</p>", "\n");
-        
-        // Remove HTML tags
-        let re = regex::Regex::new(r"<[^>]+>").unwrap_or_else(|_| regex::Regex::new("").unwrap());
-        Ok(re.replace_all(&text, "").to_string())
     }
 
     pub fn chunk_text(&self, text: &str, chunk_size: usize, overlap: usize) -> Vec<TextChunk> {
@@ -94,8 +28,6 @@ impl DocumentPipeline {
                     id: uuid::Uuid::new_v4().to_string(),
                     text: current_chunk.trim().to_string(),
                     token_count: current_tokens,
-                    page_number: None,
-                    section_header: None,
                 });
                 
                 // Start new chunk with overlap
@@ -122,11 +54,9 @@ impl DocumentPipeline {
                 id: uuid::Uuid::new_v4().to_string(),
                 text: current_chunk.trim().to_string(),
                 token_count: current_tokens,
-                page_number: None,
-                section_header: None,
             });
         }
-        
+
         chunks
     }
 
@@ -157,20 +87,6 @@ impl DocumentPipeline {
         text.len().div_ceil(4)
     }
 
-    pub fn get_page_count(&self, file_path: &Path) -> Result<Option<u32>> {
-        let extension = file_path
-            .extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("")
-            .to_lowercase();
-
-        if extension == "pdf" {
-            // In production, use a proper PDF library to get page count
-            Ok(Some(1))
-        } else {
-            Ok(None)
-        }
-    }
 }
 
 impl Default for DocumentPipeline {

--- a/src-tauri/src/services/embedding.rs
+++ b/src-tauri/src/services/embedding.rs
@@ -1,28 +1,21 @@
+use std::time::Duration;
 use reqwest::Client;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use crate::error::{AppError, Result};
 
 pub struct EmbeddingService {
     provider: String,
     api_key: String,
     model: String,
+    base_url: Option<String>,
     client: Client,
 }
 
-#[derive(Debug, Serialize)]
-struct GeminiEmbedRequest {
-    model: String,
-    content: GeminiContent,
-}
-
-#[derive(Debug, Serialize)]
-struct GeminiContent {
-    parts: Vec<GeminiPart>,
-}
-
-#[derive(Debug, Serialize)]
-struct GeminiPart {
-    text: String,
+fn redact(api_key: &str, msg: String) -> String {
+    if api_key.len() < 6 {
+        return msg;
+    }
+    msg.replace(api_key, "[REDACTED]")
 }
 
 #[derive(Debug, Deserialize)]
@@ -37,6 +30,15 @@ struct GeminiEmbedding {
 
 impl EmbeddingService {
     pub fn new(provider: &str, api_key: &str, model: Option<&str>) -> Self {
+        Self::with_base_url(provider, api_key, model, None)
+    }
+
+    pub fn with_base_url(
+        provider: &str,
+        api_key: &str,
+        model: Option<&str>,
+        base_url: Option<&str>,
+    ) -> Self {
         let default_model = match provider {
             "gemini" => "text-embedding-004",
             "openai" => "text-embedding-3-small",
@@ -44,11 +46,19 @@ impl EmbeddingService {
             _ => "text-embedding-004",
         };
 
+        let client = Client::builder()
+            .connect_timeout(Duration::from_secs(15))
+            .timeout(Duration::from_secs(60))
+            .redirect(reqwest::redirect::Policy::limited(3))
+            .build()
+            .unwrap_or_else(|_| Client::new());
+
         Self {
             provider: provider.to_string(),
             api_key: api_key.to_string(),
             model: model.unwrap_or(default_model).to_string(),
-            client: Client::new(),
+            base_url: base_url.map(String::from),
+            client,
         }
     }
 
@@ -61,14 +71,15 @@ impl EmbeddingService {
         }
     }
 
+    #[allow(dead_code)]
     pub async fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
         let mut embeddings = Vec::with_capacity(texts.len());
-        
+
         for text in texts {
             let embedding = self.embed(text).await?;
             embeddings.push(embedding);
         }
-        
+
         Ok(embeddings)
     }
 
@@ -94,9 +105,9 @@ impl EmbeddingService {
             .await?;
 
         if !response.status().is_success() {
-            return Err(AppError::Api(format!(
-                "Gemini embedding error: {}",
-                response.status()
+            return Err(AppError::Api(redact(
+                &self.api_key,
+                format!("Gemini embedding error: {}", response.status()),
             )));
         }
 
@@ -122,9 +133,9 @@ impl EmbeddingService {
             .await?;
 
         if !response.status().is_success() {
-            return Err(AppError::Api(format!(
-                "OpenAI embedding error: {}",
-                response.status()
+            return Err(AppError::Api(redact(
+                &self.api_key,
+                format!("OpenAI embedding error: {}", response.status()),
             )));
         }
 
@@ -142,7 +153,8 @@ impl EmbeddingService {
     }
 
     async fn embed_ollama(&self, text: &str) -> Result<Vec<f32>> {
-        let url = "http://localhost:11434/api/embeddings";
+        let base = self.base_url.as_deref().unwrap_or("http://localhost:11434");
+        let url = format!("{}/api/embeddings", base.trim_end_matches('/'));
 
         let body = serde_json::json!({
             "model": self.model,
@@ -151,7 +163,7 @@ impl EmbeddingService {
 
         let response = self
             .client
-            .post(url)
+            .post(&url)
             .header("Content-Type", "application/json")
             .json(&body)
             .send()
@@ -173,6 +185,7 @@ impl EmbeddingService {
         Ok(result.embedding)
     }
 
+    #[allow(dead_code)]
     pub fn dimension(&self) -> usize {
         match (self.provider.as_str(), self.model.as_str()) {
             ("gemini", "text-embedding-004") => 768,

--- a/src-tauri/src/services/vector_store.rs
+++ b/src-tauri/src/services/vector_store.rs
@@ -136,6 +136,7 @@ impl VectorStore {
     }
     
     /// Get all chunks for a document
+    #[allow(dead_code)]
     pub fn get_document_chunks(&self, document_id: &str) -> Result<Vec<DocumentChunk>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, document_id, document_name, content, embedding, chunk_index, token_count 
@@ -161,6 +162,7 @@ impl VectorStore {
     }
     
     /// Check if a document is already indexed
+    #[allow(dead_code)]
     pub fn document_exists(&self, document_id: &str) -> Result<bool> {
         let count: i64 = self.conn.query_row(
             "SELECT COUNT(*) FROM chunks WHERE document_id = ?1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import {
   isShortcutsHelpOpen,
   loadPersistedData,
   applyThemeClasses,
+  flushPendingSaves,
 } from "./stores/appStore";
 import { Spotlight } from "./components/spotlight/Spotlight";
 import { Dashboard } from "./components/dashboard/Dashboard";
@@ -41,6 +42,16 @@ export function App() {
       e.preventDefault();
     };
     document.addEventListener("contextmenu", handleContextMenu);
+
+    // Flush pending debounced saves before the window unloads. Without this
+    // a user closing the app within ~1.5s of typing can lose their last
+    // chat history / folder updates because the debounced writer hasn't
+    // fired yet.
+    const handleUnload = () => {
+      flushPendingSaves();
+    };
+    window.addEventListener("beforeunload", handleUnload);
+    window.addEventListener("pagehide", handleUnload);
 
     const handleKeyDown = async (e: KeyboardEvent) => {
       // Command Palette (Ctrl+K)
@@ -177,7 +188,12 @@ export function App() {
     };
 
     window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("beforeunload", handleUnload);
+      window.removeEventListener("pagehide", handleUnload);
+      document.removeEventListener("contextmenu", handleContextMenu);
+    };
   }, []);
 
   // Watch theme changes

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "preact/hooks";
+import { useState, useRef, useEffect, useMemo } from "preact/hooks";
 import { invoke } from "@tauri-apps/api/core";
 import { listen, UnlistenFn } from "@tauri-apps/api/event";
 import { open } from "@tauri-apps/plugin-dialog";
@@ -92,6 +92,43 @@ export function Dashboard() {
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "instant" });
   }, [currentMessages.value]);
+
+  // Group sessions by date once per chatHistory change instead of on every
+  // render. This was previously rebuilt inside the JSX IIFE on every signal
+  // update — including every streaming chunk — which is O(N) avoidable work.
+  const groupedSessions = useMemo(() => {
+    const today = new Date();
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+    const todayStr = today.toDateString();
+    const yesterdayStr = yesterday.toDateString();
+
+    const getDateGroup = (dateStr: string) => {
+      const ds = new Date(dateStr).toDateString();
+      if (ds === todayStr) return "Today";
+      if (ds === yesterdayStr) return "Yesterday";
+      return new Date(dateStr).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+    };
+
+    const grouped = chatHistory.value.reduce((acc, session) => {
+      const group = getDateGroup(session.createdAt);
+      if (!acc[group]) acc[group] = [];
+      acc[group].push(session);
+      return acc;
+    }, {} as Record<string, typeof chatHistory.value>);
+
+    const groupOrder = ["Today", "Yesterday"];
+    const sortedGroups = Object.keys(grouped).sort((a, b) => {
+      const aIdx = groupOrder.indexOf(a);
+      const bIdx = groupOrder.indexOf(b);
+      if (aIdx !== -1 && bIdx !== -1) return aIdx - bIdx;
+      if (aIdx !== -1) return -1;
+      if (bIdx !== -1) return 1;
+      return 0;
+    });
+
+    return { grouped, sortedGroups };
+  }, [chatHistory.value]);
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === "Enter" && !e.shiftKey) {
@@ -363,37 +400,7 @@ export function Dashboard() {
                     </div>
                   ))}
                 </div>
-              ) : (() => {
-                // Group chats by date
-                const getDateGroup = (dateStr: string) => {
-                  const date = new Date(dateStr);
-                  const today = new Date();
-                  const yesterday = new Date(today);
-                  yesterday.setDate(yesterday.getDate() - 1);
-
-                  if (date.toDateString() === today.toDateString()) return "Today";
-                  if (date.toDateString() === yesterday.toDateString()) return "Yesterday";
-                  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
-                };
-
-                const grouped = chatHistory.value.reduce((acc, session) => {
-                  const group = getDateGroup(session.createdAt);
-                  if (!acc[group]) acc[group] = [];
-                  acc[group].push(session);
-                  return acc;
-                }, {} as Record<string, typeof chatHistory.value>);
-
-                const groupOrder = ["Today", "Yesterday"];
-                const sortedGroups = Object.keys(grouped).sort((a, b) => {
-                  const aIdx = groupOrder.indexOf(a);
-                  const bIdx = groupOrder.indexOf(b);
-                  if (aIdx !== -1 && bIdx !== -1) return aIdx - bIdx;
-                  if (aIdx !== -1) return -1;
-                  if (bIdx !== -1) return 1;
-                  return 0;
-                });
-
-                return (
+              ) : (
                   <div className="space-y-2 px-2">
                     {chatHistory.value.length === 0 ? (
                       <div className="flex flex-col items-center gap-2 px-3 py-6 text-center">
@@ -403,11 +410,11 @@ export function Dashboard() {
                         <div className="text-xs text-text-tertiary">No conversations yet</div>
                         <div className="text-[10px] text-text-tertiary">Start chatting to see your history here</div>
                       </div>
-                    ) : sortedGroups.map(group => (
+                    ) : groupedSessions.sortedGroups.map(group => (
                       <div key={group}>
                         <div className="text-xs text-text-tertiary px-2 py-1 uppercase tracking-wide">{group}</div>
                         <div className="space-y-0.5">
-                          {grouped[group].map(session => (
+                          {groupedSessions.grouped[group].map(session => (
                             <div
                               key={session.id}
                               draggable
@@ -454,8 +461,7 @@ export function Dashboard() {
                       </div>
                     ))}
                   </div>
-                );
-              })()}
+              )}
             </>
           )}
 
@@ -562,13 +568,16 @@ export function Dashboard() {
               <button
                 onClick={() => setShowModelSelect(!showModelSelect)}
                 className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-bg-tertiary hover:bg-border transition-colors text-sm text-text-secondary"
+                aria-haspopup="listbox"
+                aria-expanded={showModelSelect}
+                aria-label={`Active model: ${activeModel.value}. Click to change.`}
               >
                 <span>{activeModel.value}</span>
                 <ChevronDownIcon size={14} />
               </button>
 
               {showModelSelect && (
-                <div className="absolute top-full left-0 mt-1 w-64 bg-bg-primary border border-border rounded-lg shadow-xl z-50 py-1 max-h-80 overflow-y-auto">
+                <div role="listbox" aria-label="Available AI models" className="absolute top-full left-0 mt-1 w-64 bg-bg-primary border border-border rounded-lg shadow-xl z-50 py-1 max-h-80 overflow-y-auto">
                   {providers.value.map(provider => (
                     <div key={provider.id}>
                       <div className="px-3 py-2 text-xs text-text-tertiary font-medium border-b border-border">
@@ -667,6 +676,11 @@ export function Dashboard() {
         <div
           className="flex-1 overflow-y-auto p-4 relative"
           ref={messagesContainerRef}
+          role="log"
+          aria-live="polite"
+          aria-relevant="additions text"
+          aria-atomic="false"
+          aria-label="Conversation"
           onScroll={(e) => {
             const el = e.target as HTMLDivElement;
             const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 100;

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -904,6 +904,8 @@ export function Dashboard() {
                 className="flex-1 bg-transparent text-text-primary placeholder:text-text-tertiary resize-none outline-none text-sm leading-6 min-h-[24px] max-h-[200px] py-0"
                 rows={1}
                 disabled={isGenerating.value}
+                maxLength={200000}
+                aria-label="Chat message input"
                 style={{ lineHeight: '24px' }}
               />
               {isGenerating.value ? (

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -29,6 +29,7 @@ import {
   stopGeneration,
   isCommandPaletteOpen,
   isMaximized,
+  setActiveModel,
 } from "../../stores/appStore";
 import { useChatSubmit, parseApiError } from "../../hooks/useChatSubmit";
 import { useDocumentLoader } from "../../hooks/useDocumentLoader";
@@ -184,8 +185,7 @@ export function Dashboard() {
   };
 
   const selectModel = (providerId: string, model: string) => {
-    activeProvider.value = providerId;
-    activeModel.value = model;
+    setActiveModel(providerId, model);
     setShowModelSelect(false);
   };
 

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -591,7 +591,7 @@ function ProviderCard({ provider }: { provider: any }) {
               {testMessage}
             </p>
           )}
-          <a href={getUrl()} target="_blank" className="text-xs text-accent-primary hover:underline">Get your API key →</a>
+          <a href={getUrl()} target="_blank" rel="noopener noreferrer" className="text-xs text-accent-primary hover:underline">Get your API key →</a>
         </div>
       ) : (
         <div className="space-y-2">

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -1,4 +1,4 @@
-import { useState } from "preact/hooks";
+import { useEffect, useRef, useState } from "preact/hooks";
 import { invoke } from "@tauri-apps/api/core";
 import {
   isSettingsOpen,
@@ -28,13 +28,62 @@ type SettingsTab = "providers" | "appearance" | "shortcuts" | "developer";
 export function Settings() {
   const [activeTab, setActiveTab] = useState<SettingsTab>("providers");
   const isCompact = viewMode.value === "spotlight";
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   const handleClose = () => {
     isSettingsOpen.value = false;
   };
 
+  // Focus trap: keep Tab navigation inside the modal so users (and screen
+  // reader users in particular) can't accidentally tab into the chat input
+  // or sidebar behind the overlay.
+  useEffect(() => {
+    const root = dialogRef.current;
+    if (!root) return;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    const focusable = (): HTMLElement[] => {
+      return Array.from(
+        root.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      ).filter(el => !el.hasAttribute("aria-hidden") && el.offsetParent !== null);
+    };
+
+    // Move focus into the modal on mount.
+    const els = focusable();
+    if (els.length > 0) els[0].focus();
+
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const items = focusable();
+      if (items.length === 0) return;
+      const first = items[0];
+      const last = items[items.length - 1];
+      const active = document.activeElement as HTMLElement;
+      if (e.shiftKey) {
+        if (active === first || !root.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    root.addEventListener("keydown", handleKey);
+    return () => {
+      root.removeEventListener("keydown", handleKey);
+      // Restore focus to whatever opened the modal so keyboard users
+      // don't get teleported back to the document body.
+      previouslyFocused?.focus?.();
+    };
+  }, []);
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-2" role="dialog" aria-modal="true" aria-label="Settings">
+    <div ref={dialogRef} className="fixed inset-0 z-50 flex items-center justify-center p-2" role="dialog" aria-modal="true" aria-label="Settings">
       <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={handleClose} />
       <div className={`relative w-full bg-bg-primary rounded-xl border border-border shadow-2xl overflow-hidden animate-fade-in ${isCompact ? "max-w-sm max-h-[90vh]" : "max-w-2xl max-h-[85vh]"
         }`}>

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -4,11 +4,11 @@ import {
   isSettingsOpen,
   providers,
   updateProviderApiKey,
+  updateProviderBaseUrl,
   setProviderConnected,
+  setActiveModel,
   theme,
   setTheme,
-  activeProvider,
-  activeModel,
   viewMode,
   globalHotkey,
 } from "../../stores/appStore";
@@ -121,9 +121,12 @@ function ProvidersTabCompact() {
 function ProviderCardCompact({ provider }: { provider: any }) {
   const [showKey, setShowKey] = useState(false);
   const [apiKey, setApiKey] = useState(provider.apiKey);
+  const [baseUrl, setBaseUrl] = useState<string>(provider.baseUrl ?? "");
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<"success" | "error" | null>(provider.isConnected ? "success" : null);
   const [testMessage, setTestMessage] = useState<string | null>(provider.isConnected ? "Connected" : null);
+
+  const effectiveBaseUrl = baseUrl.trim() || (provider.id === "ollama" ? "http://localhost:11434" : undefined);
 
   const handleTest = async () => {
     if (!apiKey && provider.id !== "ollama") return;
@@ -131,13 +134,12 @@ function ProviderCardCompact({ provider }: { provider: any }) {
     setTestResult(null);
     setTestMessage(null);
     try {
-      await invoke("test_api_key", { provider: provider.id, apiKey, baseUrl: provider.baseUrl });
+      await invoke("test_api_key", { provider: provider.id, apiKey, baseUrl: effectiveBaseUrl });
       setTestResult("success");
       setTestMessage("✓ Connected!");
       setProviderConnected(provider.id, true);
       if (!providers.value.some(p => p.isConnected)) {
-        activeProvider.value = provider.id;
-        activeModel.value = provider.models[0];
+        setActiveModel(provider.id, provider.models[0]);
       }
     } catch (err: any) {
       setTestResult("error");
@@ -156,6 +158,12 @@ function ProviderCardCompact({ provider }: { provider: any }) {
   };
 
   const handleSave = () => updateProviderApiKey(provider.id, apiKey);
+  const handleSaveBaseUrl = () => {
+    const trimmed = baseUrl.trim();
+    if (trimmed !== (provider.baseUrl ?? "")) {
+      updateProviderBaseUrl(provider.id, trimmed);
+    }
+  };
 
   const getUrl = () => {
     const urls: Record<string, string> = {
@@ -186,9 +194,10 @@ function ProviderCardCompact({ provider }: { provider: any }) {
                 onInput={(e) => setApiKey((e.target as HTMLInputElement).value)}
                 onBlur={handleSave}
                 placeholder="API key..."
+                aria-label={`${provider.name} API key`}
                 className="w-full px-2 py-1.5 pr-7 bg-bg-tertiary border border-border rounded text-text-primary text-xs outline-none focus:border-accent-primary"
               />
-              <button onClick={() => setShowKey(!showKey)} className="absolute right-1.5 top-1/2 -translate-y-1/2 text-text-tertiary hover:text-text-primary">
+              <button onClick={() => setShowKey(!showKey)} className="absolute right-1.5 top-1/2 -translate-y-1/2 text-text-tertiary hover:text-text-primary" aria-label={showKey ? "Hide API key" : "Show API key"}>
                 {showKey ? <EyeOffIcon size={12} /> : <EyeIcon size={12} />}
               </button>
             </div>
@@ -212,10 +221,19 @@ function ProviderCardCompact({ provider }: { provider: any }) {
               {testMessage}
             </p>
           )}
-          <a href={getUrl()} target="_blank" className="text-xs text-accent-primary hover:underline block">Get key →</a>
+          <a href={getUrl()} target="_blank" rel="noopener noreferrer" className="text-xs text-accent-primary hover:underline block">Get key →</a>
         </div>
       ) : (
         <div className="space-y-1.5">
+          <input
+            type="text"
+            value={baseUrl}
+            onInput={(e) => setBaseUrl((e.target as HTMLInputElement).value)}
+            onBlur={handleSaveBaseUrl}
+            placeholder="http://localhost:11434"
+            aria-label="Ollama base URL"
+            className="w-full px-2 py-1.5 bg-bg-tertiary border border-border rounded text-text-primary text-xs outline-none focus:border-accent-primary"
+          />
           <button onClick={handleTest} disabled={testing} className={`w-full px-2 py-1.5 rounded text-xs font-medium transition-all ${testing ? "bg-bg-tertiary text-text-tertiary" :
             testResult === "success" ? "bg-success/20 text-success" :
               testResult === "error" ? "bg-error/20 text-error" :
@@ -409,9 +427,18 @@ function ProvidersTab() {
 function ProviderCard({ provider }: { provider: any }) {
   const [showKey, setShowKey] = useState(false);
   const [apiKey, setApiKey] = useState(provider.apiKey);
+  const [baseUrl, setBaseUrl] = useState<string>(provider.baseUrl ?? "");
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<"success" | "error" | null>(provider.isConnected ? "success" : null);
   const [testMessage, setTestMessage] = useState<string | null>(provider.isConnected ? "API key verified" : null);
+
+  const effectiveBaseUrl = baseUrl.trim() || (provider.id === "ollama" ? "http://localhost:11434" : undefined);
+  const handleSaveBaseUrl = () => {
+    const trimmed = baseUrl.trim();
+    if (trimmed !== (provider.baseUrl ?? "")) {
+      updateProviderBaseUrl(provider.id, trimmed);
+    }
+  };
 
   const handleTest = async () => {
     if (!apiKey && provider.id !== "ollama") return;
@@ -419,13 +446,12 @@ function ProviderCard({ provider }: { provider: any }) {
     setTestResult(null);
     setTestMessage(null);
     try {
-      await invoke("test_api_key", { provider: provider.id, apiKey, baseUrl: provider.baseUrl });
+      await invoke("test_api_key", { provider: provider.id, apiKey, baseUrl: effectiveBaseUrl });
       setTestResult("success");
       setTestMessage("✓ Connection successful! API key is valid.");
       setProviderConnected(provider.id, true);
       if (!providers.value.some(p => p.isConnected)) {
-        activeProvider.value = provider.id;
-        activeModel.value = provider.models[0];
+        setActiveModel(provider.id, provider.models[0]);
       }
     } catch (err: any) {
       setTestResult("error");
@@ -520,8 +546,15 @@ function ProviderCard({ provider }: { provider: any }) {
         </div>
       ) : (
         <div className="space-y-2">
-          <input type="text" defaultValue={provider.baseUrl} placeholder="http://localhost:11434"
-            className="w-full px-3 py-2 bg-bg-tertiary border border-border rounded-lg text-text-primary text-sm outline-none focus:border-accent-primary transition-colors" />
+          <input
+            type="text"
+            value={baseUrl}
+            onInput={(e) => setBaseUrl((e.target as HTMLInputElement).value)}
+            onBlur={handleSaveBaseUrl}
+            placeholder="http://localhost:11434"
+            aria-label="Ollama base URL"
+            className="w-full px-3 py-2 bg-bg-tertiary border border-border rounded-lg text-text-primary text-sm outline-none focus:border-accent-primary transition-colors"
+          />
           <button
             onClick={handleTest}
             disabled={testing}

--- a/src/components/spotlight/Spotlight.tsx
+++ b/src/components/spotlight/Spotlight.tsx
@@ -69,9 +69,8 @@ export function Spotlight() {
       e.preventDefault();
       handleSubmit();
     }
-    if (e.key === "Escape") {
-      invoke("hide_window");
-    }
+    // Escape is handled globally in App.tsx (closes overlays, then hides
+    // window) so we deliberately don't double-handle it here.
   };
 
   const handleCopy = async () => {
@@ -358,6 +357,8 @@ export function Spotlight() {
               className="flex-1 bg-bg-tertiary rounded-lg px-3 py-2 text-text-primary placeholder:text-text-tertiary resize-none outline-none text-xs leading-relaxed min-h-[32px] max-h-[60px]"
               rows={1}
               disabled={isGenerating.value}
+              maxLength={200000}
+              aria-label="Chat message input"
             />
             {isGenerating.value ? (
               <button

--- a/src/components/spotlight/Spotlight.tsx
+++ b/src/components/spotlight/Spotlight.tsx
@@ -150,13 +150,16 @@ export function Spotlight() {
               <button
                 onClick={() => setShowModelSelect(!showModelSelect)}
                 className="flex items-center gap-1 px-2 py-1 rounded-md hover:bg-bg-tertiary transition-colors text-xs text-text-secondary"
+                aria-haspopup="listbox"
+                aria-expanded={showModelSelect}
+                aria-label={`Active model: ${activeModel.value}. Click to change.`}
               >
                 <span className="max-w-[100px] truncate">{activeModel.value}</span>
                 <ChevronDownIcon size={10} />
               </button>
 
               {showModelSelect && (
-                <div className="absolute top-full left-0 mt-1 w-52 bg-bg-secondary border border-border rounded-lg shadow-xl z-50 py-1 max-h-60 overflow-y-auto">
+                <div role="listbox" aria-label="Available AI models" className="absolute top-full left-0 mt-1 w-52 bg-bg-secondary border border-border rounded-lg shadow-xl z-50 py-1 max-h-60 overflow-y-auto">
                   {providers.value.map(provider => (
                     <div key={provider.id}>
                       <div className="px-3 py-1 text-xs text-text-tertiary font-medium">

--- a/src/components/spotlight/Spotlight.tsx
+++ b/src/components/spotlight/Spotlight.tsx
@@ -4,7 +4,6 @@ import { open } from "@tauri-apps/plugin-dialog";
 import {
   viewMode,
   activeModel,
-  activeProvider,
   providers,
   isGenerating,
   currentQuery,
@@ -15,6 +14,7 @@ import {
   Document,
   stopGeneration,
   isCommandPaletteOpen,
+  setActiveModel,
 } from "../../stores/appStore";
 import { useChatSubmit } from "../../hooks/useChatSubmit";
 import { useDocumentLoader } from "../../hooks/useDocumentLoader";
@@ -134,8 +134,7 @@ export function Spotlight() {
   };
 
   const selectModel = (providerId: string, model: string) => {
-    activeProvider.value = providerId;
-    activeModel.value = model;
+    setActiveModel(providerId, model);
     setShowModelSelect(false);
   };
 

--- a/src/hooks/useChatSubmit.ts
+++ b/src/hooks/useChatSubmit.ts
@@ -24,6 +24,12 @@ interface DocumentWithContent {
   content?: string;
 }
 
+/// Hard cap on a single user message. The actual model context window is
+/// far smaller than this, but we use the cap as a frontline guard against
+/// pasted megabytes of text (which would freeze the textarea). The error
+/// message points the user toward the document feature for large content.
+export const MAX_MESSAGE_CHARS = 200_000;
+
 // Parse and simplify API error messages for user display
 export function parseApiError(err: any): string {
   const rawMessage = err?.message || err?.toString() || "Failed to get response";
@@ -86,6 +92,15 @@ export function useChatSubmit(
 
   const handleSubmit = useCallback(async () => {
     if (!currentQuery.value.trim() || isGenerating.value) return;
+
+    if (currentQuery.value.length > MAX_MESSAGE_CHARS) {
+      setError(
+        `Message is too long (${currentQuery.value.length.toLocaleString()} characters). ` +
+        `Maximum is ${MAX_MESSAGE_CHARS.toLocaleString()}. ` +
+        `For larger content, add it as a document instead.`,
+      );
+      return;
+    }
 
     const provider = providers.value.find(p => p.id === activeProvider.value);
     if (!provider?.apiKey && provider?.id !== "ollama") {

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -799,7 +799,11 @@ export function setTheme(newTheme: Theme) {
   saveTheme();
 }
 
-// Stop generation
+// Stop generation: signal both frontend and backend to abort the in-flight stream.
 export function stopGeneration() {
   isGenerating.value = false;
+  // Tell the Rust side to drop its streaming HTTP connection. Fire-and-forget;
+  // a failure here is non-fatal because the frontend has already stopped
+  // updating the UI.
+  invoke("stop_generation").catch(() => {});
 }

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -319,14 +319,32 @@ export async function loadPersistedData() {
       chatFolders.value = savedFolders;
     }
 
-    // Load API keys
+    // Load API keys + persisted base URLs (Ollama, custom endpoints)
     const savedProviders = await s.get<AIProvider[]>("providers");
     if (savedProviders) {
-      // Merge saved API keys with current providers
       providers.value = providers.value.map(p => {
         const saved = savedProviders.find(sp => sp.id === p.id);
-        return saved ? { ...p, apiKey: saved.apiKey, isConnected: saved.isConnected } : p;
+        if (!saved) return p;
+        return {
+          ...p,
+          apiKey: saved.apiKey,
+          isConnected: saved.isConnected,
+          // Use saved base URL if present, otherwise fall back to defaults.
+          baseUrl: saved.baseUrl !== undefined ? saved.baseUrl : p.baseUrl,
+        };
       });
+    }
+
+    // Load last-used provider/model (only if they're still valid choices).
+    const savedActiveProvider = await s.get<string>("activeProvider");
+    const savedActiveModel = await s.get<string>("activeModel");
+    if (savedActiveProvider && savedActiveModel) {
+      const providerExists = providers.value.find(p => p.id === savedActiveProvider);
+      if (providerExists) {
+        activeProvider.value = savedActiveProvider;
+        // Allow custom models too (e.g. user-added Ollama tags).
+        activeModel.value = savedActiveModel;
+      }
     }
 
     // Load theme
@@ -399,7 +417,7 @@ export async function saveChatFolders() {
   });
 }
 
-// Save providers (API keys) - immediate since it's user-triggered and infrequent
+// Save providers (API keys, baseUrl) - immediate since it's user-triggered and infrequent
 export async function saveProviders() {
   try {
     const s = await getStore();
@@ -408,6 +426,31 @@ export async function saveProviders() {
   } catch (e) {
     console.error("Failed to save providers:", e);
   }
+}
+
+// Save the user's last-selected provider/model so it persists across launches.
+export async function saveActiveModel() {
+  try {
+    const s = await getStore();
+    await s.set("activeProvider", activeProvider.value);
+    await s.set("activeModel", activeModel.value);
+    await s.save();
+  } catch (e) {
+    console.error("Failed to save active model:", e);
+  }
+}
+
+export function setActiveModel(providerId: string, model: string) {
+  activeProvider.value = providerId;
+  activeModel.value = model;
+  saveActiveModel();
+}
+
+export function updateProviderBaseUrl(providerId: string, baseUrl: string) {
+  providers.value = providers.value.map((p) =>
+    p.id === providerId ? { ...p, baseUrl } : p,
+  );
+  saveProviders();
 }
 
 // Save theme - immediate since it's user-triggered


### PR DESCRIPTION
## Summary

Autonomous improvement pass targeting four buckets: real security fixes, missing UX features, persistence correctness, and accessibility polish. All changes are additive and tested locally (TypeScript build clean, cargo check clean).

### Security & correctness (Rust backend)
- Per-request connect/read timeouts on all reqwest clients (no more hung UI from a slow upstream).
- Limited redirect policy (3 hops) — defense in depth against open-redirect / SSRF amplification.
- API keys redacted from error strings before they reach the frontend or logs (Gemini / Ollama embed include the key in the URL; some upstreams echo headers).
- ``stop_generation`` now actually cancels the in-flight stream via a shared atomic flag — previously it was a no-op.
- ``read_document_content`` hardened: refuses path traversal, refuses files > 50 MB, refuses non-regular paths, restricts to an explicit allow-list of extensions, and falls back to lossy UTF-8 for log-style files.
- Removed misleading no-op ``save_api_key`` Tauri command.
- Removed crate-level ``allow(dead_code)`` / ``allow(unused_imports)`` and pruned the dead code those flags were hiding.
- ``test_api_key`` now fails fast on empty keys.
- Fixed Ollama embedding service ignoring the configured ``base_url``.

### Persistence
- Active provider/model now persists across launches (was resetting to default).
- Ollama base URL field in Settings now actually saves (was using ``defaultValue`` with no handler).
- ``flushPendingSaves`` runs on ``beforeunload`` / ``pagehide`` so debounced writes don't get lost when the user closes the app within ~1.5 s of typing.

### UX / perf / a11y
- Memoized chat-history date grouping (Today / Yesterday / older). Was rebuilt inside an IIFE on every render — including every streaming chunk.
- Settings modal now has a real focus trap; focus returns to the trigger on close.
- ``role="log"`` + ``aria-live="polite"`` on the messages container so screen readers can follow streaming responses.
- ``aria-haspopup`` / ``aria-expanded`` / ``role=listbox`` on the model selector dropdowns.
- ``aria-label`` on chat inputs, API key inputs, eye toggle, and Ollama URL input.
- ``rel="noopener noreferrer"`` on remaining external link.

### Input hardening
- 200,000-char cap on chat messages with a friendly error pointing the user toward the document feature for larger content.
- Spotlight no longer double-handles Escape (App.tsx already routes it correctly).

### npm audit
- Applied non-breaking ``npm audit fix`` (preact, postcss, rollup, picomatch).

## Test plan

- [x] ``npx tsc --noEmit`` passes.
- [x] ``npx vite build`` succeeds.
- [x] ``cargo check`` clean (no warnings).
- [x] CI green on this PR.