### PR TITLE
Custom model entries per provider + UX polish

### DIFF
--- a/src/components/common/FolderManager.tsx
+++ b/src/components/common/FolderManager.tsx
@@ -160,6 +160,25 @@ export function FolderManager({ onSelectSession }: FolderManagerProps) {
 
             {/* Folders List */}
             <div className="flex-1 overflow-y-auto">
+                {chatFolders.value.length === 0 && !isAddingFolder && (
+                    <div className="px-3 py-6 text-center">
+                        <div className="w-10 h-10 mx-auto mb-2 rounded-xl bg-bg-tertiary flex items-center justify-center">
+                            <FolderIcon size={20} className="text-text-tertiary" />
+                        </div>
+                        <p className="text-xs text-text-secondary mb-1 font-medium">Organize chats into folders</p>
+                        <p className="text-[10px] text-text-tertiary leading-relaxed mb-3">
+                            Drag any chat from the sidebar onto a folder to file it.
+                        </p>
+                        <button
+                            onClick={() => setIsAddingFolder(true)}
+                            className="inline-flex items-center gap-1 px-3 py-1.5 rounded bg-accent-primary text-white text-xs hover:bg-accent-primary/90 transition-colors"
+                        >
+                            <PlusIcon size={12} />
+                            New folder
+                        </button>
+                    </div>
+                )}
+
                 {/* Custom Folders */}
                 {chatFolders.value.map((folder) => (
                     <FolderItem

--- a/src/components/common/ModelSelector.tsx
+++ b/src/components/common/ModelSelector.tsx
@@ -1,0 +1,247 @@
+import { useState } from "preact/hooks";
+import {
+  activeModel,
+  activeProvider,
+  providers,
+  customModels,
+  setActiveModel,
+  addCustomModel,
+  removeCustomModel,
+  isCustomModel,
+  isValidModelName,
+  AIProvider,
+} from "../../stores/appStore";
+import { useClickOutside } from "../../hooks/useClickOutside";
+import { ChevronDownIcon, CloseIcon, PlusIcon, CheckIcon } from "../icons";
+
+interface ModelSelectorProps {
+  /** Compact variant for Spotlight (smaller text + tighter padding). */
+  compact?: boolean;
+}
+
+/**
+ * Unified model picker. Built-in models per provider plus user-added
+ * custom models, with an inline "Add custom model" affordance for every
+ * provider — important because cloud providers retire model names
+ * without notice and we don't want to ship a release every time.
+ */
+export function ModelSelector({ compact = false }: ModelSelectorProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useClickOutside<HTMLDivElement>(() => setOpen(false), open);
+
+  const currentProvider = providers.value.find(p => p.id === activeProvider.value);
+  const currentProviderLabel = currentProvider?.name.replace(" (Local)", "") ?? activeProvider.value;
+
+  const select = (providerId: string, model: string) => {
+    setActiveModel(providerId, model);
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen(o => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={`Active model: ${currentProviderLabel} ${activeModel.value}. Click to change.`}
+        className={`flex items-center gap-1.5 rounded-lg bg-bg-tertiary hover:bg-border transition-colors text-text-secondary ${
+          compact ? "px-2 py-1 text-xs" : "px-3 py-1.5 text-sm"
+        }`}
+      >
+        <span
+          className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${
+            currentProvider?.isConnected
+              ? "bg-success"
+              : currentProvider?.id === "ollama"
+              ? "bg-warning"
+              : "bg-text-tertiary"
+          }`}
+          aria-hidden="true"
+        />
+        <span className={`text-text-tertiary ${compact ? "max-w-[60px]" : ""} truncate`}>
+          {currentProviderLabel}
+        </span>
+        <span className={compact ? "max-w-[100px] truncate" : ""}>
+          <span className="text-text-tertiary mx-1">·</span>
+          {activeModel.value}
+        </span>
+        <ChevronDownIcon size={compact ? 10 : 14} className="flex-shrink-0" />
+      </button>
+
+      {open && (
+        <div
+          role="listbox"
+          aria-label="Available AI models"
+          className={`absolute top-full left-0 mt-1 bg-bg-primary border border-border rounded-lg shadow-xl z-50 py-1 overflow-y-auto ${
+            compact ? "w-64 max-h-72" : "w-72 max-h-96"
+          }`}
+        >
+          {providers.value.map(provider => (
+            <ProviderModelGroup
+              key={provider.id}
+              provider={provider}
+              activeProviderId={activeProvider.value}
+              activeModelName={activeModel.value}
+              onSelect={select}
+              compact={compact}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface GroupProps {
+  provider: AIProvider;
+  activeProviderId: string;
+  activeModelName: string;
+  onSelect: (providerId: string, model: string) => void;
+  compact: boolean;
+}
+
+function ProviderModelGroup({ provider, activeProviderId, activeModelName, onSelect, compact }: GroupProps) {
+  const [adding, setAdding] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const builtIns = provider.models;
+  const custom = customModels.value[provider.id] ?? [];
+  const showWarn = !provider.apiKey && provider.id !== "ollama";
+
+  const submitDraft = () => {
+    const trimmed = draft.trim();
+    if (!trimmed) {
+      setAdding(false);
+      return;
+    }
+    if (!isValidModelName(trimmed)) {
+      setError("Letters, numbers, dots, dashes, slashes, colons only.");
+      return;
+    }
+    const result = addCustomModel(provider.id, trimmed);
+    if (!result.ok) {
+      setError(result.reason);
+      return;
+    }
+    onSelect(provider.id, trimmed);
+    setDraft("");
+    setError(null);
+    setAdding(false);
+  };
+
+  return (
+    <div>
+      <div className="px-3 py-1.5 text-xs text-text-tertiary font-medium border-b border-border flex items-center justify-between">
+        <span>{provider.name}</span>
+        {showWarn && <span className="text-warning text-[10px]">(no key)</span>}
+        {provider.isConnected && (
+          <span className="text-success text-[10px] flex items-center gap-0.5">
+            <CheckIcon size={10} /> connected
+          </span>
+        )}
+      </div>
+
+      {[...builtIns, ...custom.filter(m => !builtIns.includes(m))].map(model => {
+        const isActive = activeProviderId === provider.id && activeModelName === model;
+        const userAdded = isCustomModel(provider.id, model);
+        return (
+          <div
+            key={model}
+            className={`group flex items-center justify-between hover:bg-bg-tertiary transition-colors ${
+              isActive ? "bg-accent-primary/10" : ""
+            }`}
+          >
+            <button
+              role="option"
+              aria-selected={isActive}
+              onClick={() => onSelect(provider.id, model)}
+              className={`flex-1 text-left px-3 py-2 truncate ${
+                compact ? "text-xs" : "text-sm"
+              } ${isActive ? "text-accent-primary" : "text-text-primary"}`}
+            >
+              {model}
+              {userAdded && (
+                <span className="ml-2 text-[10px] text-text-tertiary uppercase tracking-wide">custom</span>
+              )}
+            </button>
+            {userAdded && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  removeCustomModel(provider.id, model);
+                }}
+                className="opacity-0 group-hover:opacity-100 p-1 mr-1.5 rounded text-text-tertiary hover:text-error hover:bg-error/10 transition-all"
+                aria-label={`Remove custom model ${model}`}
+                title="Remove custom model"
+              >
+                <CloseIcon size={10} />
+              </button>
+            )}
+          </div>
+        );
+      })}
+
+      {/* Add custom model affordance — available for every provider, not just Ollama. */}
+      <div className="px-3 py-2 border-t border-border bg-bg-secondary/30">
+        {adding ? (
+          <div className="space-y-1">
+            <input
+              type="text"
+              autoFocus
+              value={draft}
+              onInput={(e) => {
+                setDraft((e.target as HTMLInputElement).value);
+                setError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  submitDraft();
+                }
+                if (e.key === "Escape") {
+                  e.preventDefault();
+                  setAdding(false);
+                  setDraft("");
+                  setError(null);
+                }
+              }}
+              placeholder={
+                provider.id === "ollama"
+                  ? "e.g. llama3.2:1b"
+                  : provider.id === "gemini"
+                  ? "e.g. gemini-2.5-pro"
+                  : provider.id === "openai"
+                  ? "e.g. gpt-4o-mini"
+                  : provider.id === "anthropic"
+                  ? "e.g. claude-3-5-sonnet-20241022"
+                  : "exact model id"
+              }
+              maxLength={80}
+              aria-label={`Custom ${provider.name} model name`}
+              className={`w-full px-2 py-1 bg-bg-tertiary border border-border rounded text-text-primary placeholder:text-text-tertiary outline-none focus:border-accent-primary ${
+                compact ? "text-xs" : "text-sm"
+              }`}
+            />
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-[10px] text-text-tertiary">
+                Enter to save · Esc to cancel
+              </p>
+              {error && <p className="text-[10px] text-error">{error}</p>}
+            </div>
+          </div>
+        ) : (
+          <button
+            onClick={() => setAdding(true)}
+            className={`w-full flex items-center gap-1.5 text-left text-text-tertiary hover:text-accent-primary transition-colors ${
+              compact ? "text-xs" : "text-sm"
+            }`}
+          >
+            <PlusIcon size={12} />
+            <span>Add custom model</span>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -29,12 +29,10 @@ import {
   stopGeneration,
   isCommandPaletteOpen,
   isMaximized,
-  setActiveModel,
 } from "../../stores/appStore";
 import { useChatSubmit, parseApiError } from "../../hooks/useChatSubmit";
 import { useDocumentLoader } from "../../hooks/useDocumentLoader";
 import { useDebouncedSearch } from "../../hooks/useDebouncedSearch";
-import { useClickOutside } from "../../hooks/useClickOutside";
 import { useAutoResize } from "../../hooks/useAutoResize";
 import {
   LogoIcon,
@@ -61,6 +59,7 @@ import { Markdown } from "../common/Markdown";
 import { TokenCounter } from "../common/TokenCounter";
 import { ExportImport } from "../common/ExportImport";
 import { FolderManager } from "../common/FolderManager";
+import { ModelSelector } from "../common/ModelSelector";
 import { WindowControls, DragRegion } from "../common/WindowControls";
 import { RagDebugPanel } from "../common/RagDebugPanel";
 import { DocumentListSkeleton } from "../common/Skeleton";
@@ -69,7 +68,6 @@ export function Dashboard() {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
-  const [showModelSelect, setShowModelSelect] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [sidebarTab, setSidebarTab] = useState<"chats" | "folders" | "docs">("chats");
   const [showExport, setShowExport] = useState(false);
@@ -83,7 +81,6 @@ export function Dashboard() {
   const { docsWithContent, loadingDocs, totalDocsLoaded } = useDocumentLoader();
   const { localSearchQuery, setLocalSearchQuery } = useDebouncedSearch(300);
   const { handleSubmit, cleanupStream } = useChatSubmit(docsWithContent, setError);
-  const modelSelectorRef = useClickOutside<HTMLDivElement>(() => setShowModelSelect(false), showModelSelect);
   const handleAutoResize = useAutoResize(200);
 
   // Clean up stream listener on unmount
@@ -221,11 +218,6 @@ export function Dashboard() {
     removeDocument(docId);
   };
 
-  const selectModel = (providerId: string, model: string) => {
-    setActiveModel(providerId, model);
-    setShowModelSelect(false);
-  };
-
   const handleCopyMessage = async (content: string, messageId: string) => {
     await navigator.clipboard.writeText(content);
     setCopiedMessageId(messageId);
@@ -323,9 +315,11 @@ export function Dashboard() {
           <button
             onClick={handleNewChat}
             className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-accent-primary text-white text-sm hover:bg-accent-primary/90 transition-colors"
+            title="New Chat (Ctrl+N)"
           >
             <PlusIcon size={16} />
-            New Chat
+            <span>New Chat</span>
+            <kbd className="ml-auto px-1.5 py-0.5 bg-white/15 rounded text-[10px] font-mono">Ctrl+N</kbd>
           </button>
 
           {/* Sidebar Tabs */}
@@ -564,61 +558,8 @@ export function Dashboard() {
             <span className="font-semibold text-text-primary">OmniRecall</span>
 
             {/* Model Selector */}
-            <div className="relative ml-4" ref={modelSelectorRef}>
-              <button
-                onClick={() => setShowModelSelect(!showModelSelect)}
-                className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-bg-tertiary hover:bg-border transition-colors text-sm text-text-secondary"
-                aria-haspopup="listbox"
-                aria-expanded={showModelSelect}
-                aria-label={`Active model: ${activeModel.value}. Click to change.`}
-              >
-                <span>{activeModel.value}</span>
-                <ChevronDownIcon size={14} />
-              </button>
-
-              {showModelSelect && (
-                <div role="listbox" aria-label="Available AI models" className="absolute top-full left-0 mt-1 w-64 bg-bg-primary border border-border rounded-lg shadow-xl z-50 py-1 max-h-80 overflow-y-auto">
-                  {providers.value.map(provider => (
-                    <div key={provider.id}>
-                      <div className="px-3 py-2 text-xs text-text-tertiary font-medium border-b border-border">
-                        {provider.name}
-                        {!provider.apiKey && provider.id !== "ollama" && (
-                          <span className="text-warning ml-1">(no key)</span>
-                        )}
-                      </div>
-                      {provider.models.map(model => (
-                        <button
-                          key={model}
-                          onClick={() => selectModel(provider.id, model)}
-                          className={`w-full text-left px-3 py-2 text-sm hover:bg-bg-tertiary transition-colors ${activeModel.value === model ? "text-accent-primary bg-accent-primary/10" : "text-text-primary"
-                            }`}
-                        >
-                          {model}
-                        </button>
-                      ))}
-                      {provider.id === "ollama" && (
-                        <div className="px-3 py-2 border-t border-border mt-1">
-                          <input
-                            type="text"
-                            placeholder="Enter custom model name..."
-                            className="w-full px-2 py-1.5 bg-bg-tertiary border border-border rounded text-sm text-text-primary placeholder:text-text-tertiary outline-none focus:border-accent-primary"
-                            onKeyDown={(e) => {
-                              if (e.key === "Enter") {
-                                const value = (e.target as HTMLInputElement).value.trim();
-                                if (value) {
-                                  selectModel("ollama", value);
-                                  (e.target as HTMLInputElement).value = "";
-                                }
-                              }
-                            }}
-                          />
-                          <p className="text-xs text-text-tertiary mt-1">Press Enter to use custom model</p>
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              )}
+            <div className="ml-4">
+              <ModelSelector />
             </div>
 
             {/* Token Counter */}
@@ -642,7 +583,8 @@ export function Dashboard() {
               <button
                 onClick={() => setShowExport(true)}
                 className="p-2 rounded-lg hover:bg-bg-tertiary transition-colors text-text-tertiary hover:text-text-primary"
-                title="Export Chat"
+                title="Export chat"
+                aria-label="Export chat"
               >
                 <DownloadIcon size={18} />
               </button>
@@ -650,14 +592,16 @@ export function Dashboard() {
             <button
               onClick={() => (isSettingsOpen.value = true)}
               className="p-2 rounded-lg hover:bg-bg-tertiary transition-colors text-text-tertiary hover:text-text-primary"
-              title="Settings"
+              title="Settings (Ctrl+,)"
+              aria-label="Settings"
             >
               <SettingsIcon size={18} />
             </button>
             <button
               onClick={handleBackToSpotlight}
               className="p-2 rounded-lg hover:bg-bg-tertiary transition-colors text-text-tertiary hover:text-text-primary"
-              title="Back to Spotlight"
+              title="Back to Spotlight (Esc)"
+              aria-label="Back to Spotlight"
             >
               <CloseIcon size={16} />
             </button>
@@ -883,8 +827,25 @@ export function Dashboard() {
 
         {/* Error */}
         {error && (
-          <div className="px-4 py-2 bg-error/10 border-t border-error/20">
-            <p className="text-sm text-error text-center">{error}</p>
+          <div className="px-4 py-2 bg-error/10 border-t border-error/20 flex items-center justify-between gap-3" role="alert">
+            <p className="text-sm text-error flex-1">{error}</p>
+            <div className="flex items-center gap-1.5 flex-shrink-0">
+              {/Settings|API key/i.test(error) && (
+                <button
+                  onClick={() => (isSettingsOpen.value = true)}
+                  className="px-2.5 py-1 rounded text-xs bg-error/20 text-error hover:bg-error/30 transition-colors"
+                >
+                  Open Settings
+                </button>
+              )}
+              <button
+                onClick={() => setError(null)}
+                className="p-1 rounded text-error/70 hover:text-error hover:bg-error/10 transition-colors"
+                aria-label="Dismiss error"
+              >
+                <CloseIcon size={12} />
+              </button>
+            </div>
           </div>
         )}
 
@@ -913,6 +874,7 @@ export function Dashboard() {
                   onClick={stopGeneration}
                   className="p-2 rounded-lg bg-error text-white hover:bg-error/90 transition-all flex-shrink-0"
                   title="Stop generating (Ctrl+.)"
+                  aria-label="Stop generating"
                 >
                   <StopIcon size={18} />
                 </button>
@@ -924,9 +886,23 @@ export function Dashboard() {
                     ? "bg-accent-primary text-white hover:bg-accent-primary/90"
                     : "bg-bg-tertiary text-text-tertiary cursor-not-allowed"
                     }`}
+                  title={currentQuery.value.trim() ? "Send (Enter)" : "Type a message to send"}
+                  aria-label={currentQuery.value.trim() ? "Send message" : "Send disabled — type a message first"}
                 >
                   <SendIcon size={18} />
                 </button>
+              )}
+            </div>
+            {/* Footer: character counter (only when getting close to limit) and shortcut hints */}
+            <div className="flex items-center justify-between mt-1.5 px-1 text-[10px] text-text-tertiary">
+              <div className="flex items-center gap-3">
+                <span><kbd className="px-1 py-0.5 bg-bg-tertiary rounded">Enter</kbd> send</span>
+                <span><kbd className="px-1 py-0.5 bg-bg-tertiary rounded">Shift</kbd>+<kbd className="px-1 py-0.5 bg-bg-tertiary rounded">Enter</kbd> newline</span>
+              </div>
+              {currentQuery.value.length > 100_000 && (
+                <span className={currentQuery.value.length > 180_000 ? "text-warning" : ""}>
+                  {currentQuery.value.length.toLocaleString()} / 200,000
+                </span>
               )}
             </div>
           </div>

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -554,11 +554,13 @@ export function Dashboard() {
             >
               <MenuIcon size={18} />
             </button>
-            <LogoIcon size={24} className="text-accent-primary" />
-            <span className="font-semibold text-text-primary">OmniRecall</span>
+            <LogoIcon size={22} className="text-accent-primary" aria-hidden="true" />
+            {/* App name only at wider widths - keeps the header airy when the
+                model selector / token counter / doc badge are all visible. */}
+            <span className="hidden lg:inline font-semibold text-text-primary">OmniRecall</span>
 
             {/* Model Selector */}
-            <div className="ml-4">
+            <div className="lg:ml-3 ml-1">
               <ModelSelector />
             </div>
 
@@ -568,27 +570,37 @@ export function Dashboard() {
             )}
 
             {totalDocsLoaded > 0 && (
-              <div className="flex items-center gap-1.5 px-2 py-1 bg-accent-primary/10 rounded-lg">
+              <button
+                onClick={() => { setSidebarOpen(true); setSidebarTab("docs"); }}
+                className="flex items-center gap-1.5 px-2 py-1 bg-accent-primary/10 rounded-lg hover:bg-accent-primary/20 transition-colors"
+                title={`${totalDocsLoaded} document${totalDocsLoaded > 1 ? "s" : ""} loaded — click to manage`}
+                aria-label={`Manage ${totalDocsLoaded} loaded document${totalDocsLoaded > 1 ? "s" : ""}`}
+              >
                 <DocumentIcon size={14} className="text-accent-primary" />
                 <span className="text-xs text-accent-primary">{totalDocsLoaded} doc{totalDocsLoaded > 1 ? 's' : ''}</span>
-              </div>
+              </button>
             )}
           </div>
 
           {/* Drag Area - invisible but draggable */}
           <DragRegion className="h-full" />
 
-          <div className="flex items-center gap-1 no-drag">
+          <div className="flex items-center gap-0.5 no-drag">
+            {/* Per-chat actions cluster (only visible when there's a session). */}
             {currentSession && (
-              <button
-                onClick={() => setShowExport(true)}
-                className="p-2 rounded-lg hover:bg-bg-tertiary transition-colors text-text-tertiary hover:text-text-primary"
-                title="Export chat"
-                aria-label="Export chat"
-              >
-                <DownloadIcon size={18} />
-              </button>
+              <>
+                <button
+                  onClick={() => setShowExport(true)}
+                  className="p-2 rounded-lg hover:bg-bg-tertiary transition-colors text-text-tertiary hover:text-text-primary"
+                  title="Export chat"
+                  aria-label="Export chat"
+                >
+                  <DownloadIcon size={18} />
+                </button>
+                <span className="mx-1 h-5 w-px bg-border" aria-hidden="true" />
+              </>
             )}
+            {/* App-level actions cluster. */}
             <button
               onClick={() => (isSettingsOpen.value = true)}
               className="p-2 rounded-lg hover:bg-bg-tertiary transition-colors text-text-tertiary hover:text-text-primary"
@@ -607,7 +619,7 @@ export function Dashboard() {
             </button>
 
             {/* Window Controls */}
-            <div className="ml-2 border-l border-border pl-2">
+            <div className="ml-1 border-l border-border pl-1">
               <WindowControls
                 isMaximized={isMaximized.value}
                 showFullscreen={false}
@@ -624,6 +636,7 @@ export function Dashboard() {
           aria-live="polite"
           aria-relevant="additions text"
           aria-atomic="false"
+          aria-busy={isGenerating.value}
           aria-label="Conversation"
           onScroll={(e) => {
             const el = e.target as HTMLDivElement;
@@ -753,16 +766,23 @@ export function Dashboard() {
                       <Markdown content={message.content} className="text-sm leading-relaxed" />
                     )}
 
-                    {/* Message Actions - Always visible */}
-                    <div className={`flex items-center gap-1 mt-2 ${message.role === "user" ? "justify-end" : "justify-start"
-                      }`}>
+                    {/* Message actions: hidden until message is hovered/focused
+                        to keep messages visually clean. The copy button stays
+                        visible briefly after copying so the success state is
+                        readable. */}
+                    <div className={`flex items-center gap-1 mt-2 transition-opacity ${
+                        copiedMessageId === message.id
+                          ? "opacity-100"
+                          : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                      } ${message.role === "user" ? "justify-end" : "justify-start"}`}>
                       <button
                         onClick={() => handleCopyMessage(message.content, message.id)}
-                        className={`p-1 rounded text-xs ${message.role === "user"
-                          ? "text-white/60 hover:text-white hover:bg-white/10"
+                        className={`p-1.5 rounded min-w-[28px] min-h-[28px] flex items-center justify-center text-xs ${message.role === "user"
+                          ? "text-white/70 hover:text-white hover:bg-white/10"
                           : "text-text-tertiary hover:text-text-primary hover:bg-bg-tertiary"
                           }`}
-                        title="Copy"
+                        title={copiedMessageId === message.id ? "Copied!" : "Copy message"}
+                        aria-label="Copy message"
                       >
                         {copiedMessageId === message.id ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
                       </button>
@@ -771,8 +791,9 @@ export function Dashboard() {
                       {message.role === "assistant" && index === currentMessages.value.length - 1 && !isGenerating.value && (
                         <button
                           onClick={() => handleRegenerate(message.id)}
-                          className="p-1 rounded text-xs text-text-tertiary hover:text-text-primary hover:bg-bg-tertiary"
-                          title="Regenerate (creates a new branch)"
+                          className="p-1.5 rounded min-w-[28px] min-h-[28px] flex items-center justify-center text-xs text-text-tertiary hover:text-text-primary hover:bg-bg-tertiary"
+                          title="Regenerate response (creates a new branch)"
+                          aria-label="Regenerate response"
                         >
                           <RegenerateIcon size={12} />
                         </button>
@@ -782,8 +803,9 @@ export function Dashboard() {
                       {message.role === "assistant" && index < currentMessages.value.length - 1 && (
                         <button
                           onClick={() => handleBranch(message.id)}
-                          className="p-1 rounded text-xs text-text-tertiary hover:text-text-primary hover:bg-bg-tertiary"
-                          title="Branch from here"
+                          className="p-1.5 rounded min-w-[28px] min-h-[28px] flex items-center justify-center text-xs text-text-tertiary hover:text-text-primary hover:bg-bg-tertiary"
+                          title="Branch conversation from here"
+                          aria-label="Branch from this message"
                         >
                           <BranchIcon size={12} />
                         </button>

--- a/src/components/spotlight/Spotlight.tsx
+++ b/src/components/spotlight/Spotlight.tsx
@@ -3,8 +3,6 @@ import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import {
   viewMode,
-  activeModel,
-  providers,
   isGenerating,
   currentQuery,
   isSettingsOpen,
@@ -14,11 +12,9 @@ import {
   Document,
   stopGeneration,
   isCommandPaletteOpen,
-  setActiveModel,
 } from "../../stores/appStore";
 import { useChatSubmit } from "../../hooks/useChatSubmit";
 import { useDocumentLoader } from "../../hooks/useDocumentLoader";
-import { useClickOutside } from "../../hooks/useClickOutside";
 import { useAutoResize } from "../../hooks/useAutoResize";
 import {
   LogoIcon,
@@ -27,7 +23,6 @@ import {
   ExpandIcon,
   CopyIcon,
   RefreshIcon,
-  ChevronDownIcon,
   CloseIcon,
   FolderIcon,
   TypingIndicator,
@@ -36,20 +31,19 @@ import {
   CommandIcon,
 } from "../icons";
 import { Markdown } from "../common/Markdown";
+import { ModelSelector } from "../common/ModelSelector";
 import { TokenCounter } from "../common/TokenCounter";
 
 export function Spotlight() {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [copied, setCopied] = useState(false);
-  const [showModelSelect, setShowModelSelect] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
 
   // Shared hooks - eliminates code duplication with Dashboard
   const { docsWithContent, totalDocsLoaded } = useDocumentLoader();
   const { handleSubmit, cleanupStream } = useChatSubmit(docsWithContent, setError);
-  const modelSelectorRef = useClickOutside<HTMLDivElement>(() => setShowModelSelect(false), showModelSelect);
   const handleAutoResize = useAutoResize(60);
 
   // Clean up stream listener on unmount
@@ -132,11 +126,6 @@ export function Spotlight() {
     }
   };
 
-  const selectModel = (providerId: string, model: string) => {
-    setActiveModel(providerId, model);
-    setShowModelSelect(false);
-  };
-
   return (
     <div className="h-full w-full flex flex-col">
       <div className="glass rounded-xl border border-border shadow-2xl overflow-hidden animate-fade-in m-2 flex flex-col flex-1">
@@ -145,59 +134,7 @@ export function Spotlight() {
           <div className="flex items-center gap-2 no-drag">
             <LogoIcon size={18} className="text-accent-primary" />
 
-            <div className="relative" ref={modelSelectorRef}>
-              <button
-                onClick={() => setShowModelSelect(!showModelSelect)}
-                className="flex items-center gap-1 px-2 py-1 rounded-md hover:bg-bg-tertiary transition-colors text-xs text-text-secondary"
-                aria-haspopup="listbox"
-                aria-expanded={showModelSelect}
-                aria-label={`Active model: ${activeModel.value}. Click to change.`}
-              >
-                <span className="max-w-[100px] truncate">{activeModel.value}</span>
-                <ChevronDownIcon size={10} />
-              </button>
-
-              {showModelSelect && (
-                <div role="listbox" aria-label="Available AI models" className="absolute top-full left-0 mt-1 w-52 bg-bg-secondary border border-border rounded-lg shadow-xl z-50 py-1 max-h-60 overflow-y-auto">
-                  {providers.value.map(provider => (
-                    <div key={provider.id}>
-                      <div className="px-3 py-1 text-xs text-text-tertiary font-medium">
-                        {provider.name}
-                      </div>
-                      {provider.models.map(model => (
-                        <button
-                          key={model}
-                          onClick={() => selectModel(provider.id, model)}
-                          className={`w-full text-left px-3 py-1.5 text-xs hover:bg-bg-tertiary transition-colors ${activeModel.value === model ? "text-accent-primary bg-accent-primary/10" : "text-text-primary"
-                            }`}
-                        >
-                          {model}
-                        </button>
-                      ))}
-                      {provider.id === "ollama" && (
-                        <div className="px-3 py-2 border-t border-border mt-1">
-                          <input
-                            type="text"
-                            placeholder="Custom model name..."
-                            className="w-full px-2 py-1.5 bg-bg-tertiary border border-border rounded text-xs text-text-primary placeholder:text-text-tertiary outline-none focus:border-accent-primary"
-                            onKeyDown={(e) => {
-                              if (e.key === "Enter") {
-                                const value = (e.target as HTMLInputElement).value.trim();
-                                if (value) {
-                                  selectModel("ollama", value);
-                                  (e.target as HTMLInputElement).value = "";
-                                }
-                              }
-                            }}
-                          />
-                          <p className="text-xs text-text-tertiary mt-1">Press Enter to use</p>
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
+            <ModelSelector compact />
 
             {/* Token Counter */}
             {currentMessages.value.length > 0 && (
@@ -337,8 +274,25 @@ export function Spotlight() {
 
         {/* Error */}
         {error && (
-          <div className="px-3 py-2 bg-error/10 border-t border-error/20">
-            <p className="text-xs text-error">{error}</p>
+          <div className="px-3 py-2 bg-error/10 border-t border-error/20 flex items-center justify-between gap-2" role="alert">
+            <p className="text-xs text-error flex-1">{error}</p>
+            <div className="flex items-center gap-1 flex-shrink-0">
+              {/Settings|API key/i.test(error) && (
+                <button
+                  onClick={() => (isSettingsOpen.value = true)}
+                  className="px-2 py-0.5 rounded text-[10px] bg-error/20 text-error hover:bg-error/30 transition-colors"
+                >
+                  Settings
+                </button>
+              )}
+              <button
+                onClick={() => setError(null)}
+                className="p-0.5 rounded text-error/70 hover:text-error transition-colors"
+                aria-label="Dismiss error"
+              >
+                <CloseIcon size={10} />
+              </button>
+            </div>
           </div>
         )}
 
@@ -365,6 +319,7 @@ export function Spotlight() {
                 onClick={stopGeneration}
                 className="p-2 rounded-lg bg-error text-white hover:bg-error/90 transition-all flex-shrink-0"
                 title="Stop generating (Ctrl+.)"
+                aria-label="Stop generating"
               >
                 <StopIcon size={14} />
               </button>
@@ -376,6 +331,8 @@ export function Spotlight() {
                   ? "bg-accent-primary text-white hover:bg-accent-primary/90"
                   : "bg-bg-tertiary text-text-tertiary cursor-not-allowed"
                   }`}
+                title={currentQuery.value.trim() ? "Send (Enter)" : "Type a message to send"}
+                aria-label={currentQuery.value.trim() ? "Send message" : "Send disabled — type a message first"}
               >
                 <SendIcon size={14} />
               </button>

--- a/src/hooks/useChatSubmit.ts
+++ b/src/hooks/useChatSubmit.ts
@@ -104,7 +104,9 @@ export function useChatSubmit(
 
     const provider = providers.value.find(p => p.id === activeProvider.value);
     if (!provider?.apiKey && provider?.id !== "ollama") {
-      setError("Please add your API key in Settings");
+      setError(
+        `No API key for ${provider?.name ?? activeProvider.value}. Open Settings (Ctrl+,) to add one.`,
+      );
       return;
     }
 

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -157,6 +157,46 @@ export const providers = signal<AIProvider[]>([
 export const activeProvider = signal("gemini");
 export const activeModel = signal<string>("gemini-3-flash-preview");
 
+/// User-added model names per provider. Persists across launches and is
+/// merged on top of the built-in model list in the dropdown so users can
+/// still reach a model when a provider deprecates a hard-coded one
+/// (Google in particular retires preview names without warning).
+export const customModels = signal<Record<string, string[]>>({});
+
+/// Hard cap so a runaway paste can't bloat the JSON store. Anything
+/// remotely real is well under this length.
+const MAX_MODEL_NAME_LENGTH = 80;
+const VALID_MODEL_NAME_RE = /^[A-Za-z0-9._:\-/]+$/;
+
+export function isValidModelName(name: string): boolean {
+  const trimmed = name.trim();
+  return (
+    trimmed.length > 0 &&
+    trimmed.length <= MAX_MODEL_NAME_LENGTH &&
+    VALID_MODEL_NAME_RE.test(trimmed)
+  );
+}
+
+export function getProviderModels(providerId: string): string[] {
+  const provider = providers.value.find(p => p.id === providerId);
+  const built = provider ? provider.models : [];
+  const custom = customModels.value[providerId] ?? [];
+  // De-dupe while preserving original order; built-ins first, then custom.
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const m of [...built, ...custom]) {
+    if (!seen.has(m)) {
+      seen.add(m);
+      result.push(m);
+    }
+  }
+  return result;
+}
+
+export function isCustomModel(providerId: string, model: string): boolean {
+  return (customModels.value[providerId] ?? []).includes(model);
+}
+
 // Documents State
 export const documents = signal<Document[]>([]);
 
@@ -229,6 +269,9 @@ export async function flushPendingSaves() {
     await s.set("providers", providers.value);
     await s.set("documents", documents.value);
     await s.set("theme", theme.value);
+    await s.set("customModels", customModels.value);
+    await s.set("activeProvider", activeProvider.value);
+    await s.set("activeModel", activeModel.value);
     await s.save();
   } catch (e) {
     console.error("Failed to flush saves:", e);
@@ -335,6 +378,13 @@ export async function loadPersistedData() {
       });
     }
 
+    // Load user-added custom models before resolving the active model so we
+    // can recognize a custom model as valid on restore.
+    const savedCustom = await s.get<Record<string, string[]>>("customModels");
+    if (savedCustom && typeof savedCustom === "object") {
+      customModels.value = savedCustom;
+    }
+
     // Load last-used provider/model (only if they're still valid choices).
     const savedActiveProvider = await s.get<string>("activeProvider");
     const savedActiveModel = await s.get<string>("activeModel");
@@ -425,6 +475,55 @@ export async function saveProviders() {
     await s.save();
   } catch (e) {
     console.error("Failed to save providers:", e);
+  }
+}
+
+async function saveCustomModels() {
+  try {
+    const s = await getStore();
+    await s.set("customModels", customModels.value);
+    await s.save();
+  } catch (e) {
+    console.error("Failed to save custom models:", e);
+  }
+}
+
+export function addCustomModel(providerId: string, model: string): { ok: true } | { ok: false; reason: string } {
+  const trimmed = model.trim();
+  if (!isValidModelName(trimmed)) {
+    return { ok: false, reason: "Invalid model name. Use letters, numbers, dots, dashes, slashes or colons." };
+  }
+  const provider = providers.value.find(p => p.id === providerId);
+  if (provider?.models.includes(trimmed)) {
+    return { ok: false, reason: "That model is already in the built-in list." };
+  }
+  const existing = customModels.value[providerId] ?? [];
+  if (existing.includes(trimmed)) {
+    return { ok: false, reason: "Already added." };
+  }
+  customModels.value = {
+    ...customModels.value,
+    [providerId]: [...existing, trimmed],
+  };
+  saveCustomModels();
+  return { ok: true };
+}
+
+export function removeCustomModel(providerId: string, model: string) {
+  const existing = customModels.value[providerId] ?? [];
+  const next = existing.filter(m => m !== model);
+  if (next.length === existing.length) return;
+  customModels.value = { ...customModels.value, [providerId]: next };
+  saveCustomModels();
+
+  // If the removed model was the active one, fall back to the first
+  // available built-in / remaining custom model for the same provider.
+  if (activeProvider.value === providerId && activeModel.value === model) {
+    const remaining = getProviderModels(providerId);
+    if (remaining.length > 0) {
+      activeModel.value = remaining[0];
+      saveActiveModel();
+    }
   }
 }
 


### PR DESCRIPTION
## Why

Cloud providers (Google in particular) retire model names without warning — when they do, the hard-coded list in this repo ages out and users get stuck on "model not found" with no recovery short of a release. This PR makes the workaround official: every provider gets the same "+ Add custom model" affordance Ollama already had, and the entries persist.

It also bundles a focused UX/clunkiness pass.

## Custom models

- New ``customModels`` signal keyed by providerId, persisted across launches via the Tauri store.
- ``addCustomModel`` / ``removeCustomModel`` actions with validation (allow-list of name characters, length cap, dedupe vs built-ins).
- Removing the active custom model gracefully falls back to the next available model for that provider.
- New shared ``<ModelSelector />`` component used by both Dashboard and Spotlight (deletes ~120 lines of duplicated dropdown markup + a click-outside ref). Dropdown:
  - groups by provider with built-in models first, then user-added,
  - shows a status dot per provider (success / warning for ollama / unconfigured),
  - marks user-added models with a CUSTOM badge and a hover-to-remove ×,
  - exposes "+ Add custom model" for **every** provider, not just Ollama.
- Trigger button shows ``Provider · model-name`` with a status dot so the active connection state is visible at a glance.

## UX polish

- New Chat button shows the ``Ctrl+N`` shortcut as an inline kbd.
- Header tooltips include keyboard shortcuts (``Settings (Ctrl+,)``, ``Back to Spotlight (Esc)``) plus aria-labels.
- Send button explains itself when disabled: ``Type a message to send`` instead of just looking grayed out.
- Input area gets a footer with ``Enter`` / ``Shift+Enter`` hints and a character counter that appears past 100k and turns warning past 180k so the 200k cap doesn't surprise anyone.
- Error banner is now actionable: ``Open Settings`` button when the message references API keys / Settings, plus a dismiss × so it doesn't permanently steal vertical space. ``role="alert"`` for screen readers.
- "No API key" error names the specific provider and points at ``Ctrl+,``.
- Folders sidebar gets a real empty state ("Organize chats into folders" + drag instruction + create button) instead of just a tiny + icon.
- Header is decluttered: app name hides at narrower widths, doc badge becomes a clickable shortcut to the Docs sidebar tab, visual separator between per-chat actions (export) and app-level actions (settings / back to spotlight).
- Message action buttons (copy / regenerate / branch) hide until the message is hovered/focused, so a long conversation isn't visually noisy. Touch targets bumped from 12px to 28×28 to clear the WCAG 2.5.8 minimum.
- ``aria-busy`` on the message log while generating; ``aria-label`` on the message-action icon buttons.

## Test plan

- [x] ``npx tsc --noEmit`` — clean
- [x] ``npx vite build`` — builds, ~181 KB JS / 47.7 KB gzipped
- [x] ``cargo check`` — clean, no warnings
- [x] CI green on this PR