### PR TITLE
UI/UX overhaul: correctness, accessibility, smoothness, features & backend resilience

### DIFF
--- a/src-tauri/src/commands/documents.rs
+++ b/src-tauri/src/commands/documents.rs
@@ -20,69 +20,84 @@ fn is_allowed_extension(ext: &str) -> bool {
     ALLOWED_EXTENSIONS.iter().any(|allowed| allowed.eq_ignore_ascii_case(ext))
 }
 
+/// Public command: read a document's text for inline display, truncated to a
+/// sane size to avoid blowing the model context window.
 #[tauri::command]
 pub async fn read_document_content(file_path: String) -> Result<String> {
-    // Reject obvious traversal patterns. We cannot meaningfully sandbox the
-    // filesystem here (the user's own dialog picks arbitrary absolute paths)
-    // but we can still refuse paths whose components include `..`, which are
-    // never produced by the dialog and only show up if a caller is trying to
-    // confuse path resolution downstream.
-    if file_path.split(['/', '\\']).any(|s| s == "..") {
-        return Err(AppError::File("Path traversal patterns are not allowed".to_string()));
-    }
+    read_document_text(file_path, Some(100_000)).await
+}
 
-    let path = Path::new(&file_path);
-
-    if !path.exists() {
-        return Err(AppError::File(format!("File not found: {}", file_path)));
-    }
-
-    let metadata = fs::metadata(path).map_err(|e| AppError::File(e.to_string()))?;
-    if !metadata.is_file() {
-        return Err(AppError::File("Path is not a regular file".to_string()));
-    }
-    if metadata.len() > MAX_DOCUMENT_BYTES {
-        return Err(AppError::File(format!(
-            "File too large ({} MB). Maximum supported size is {} MB.",
-            metadata.len() / 1_048_576,
-            MAX_DOCUMENT_BYTES / 1_048_576,
-        )));
-    }
-
-    let extension = path.extension()
-        .and_then(|e| e.to_str())
-        .unwrap_or("")
-        .to_lowercase();
-
-    if !is_allowed_extension(&extension) {
-        return Err(AppError::File(format!("Unsupported file type: .{}", extension)));
-    }
-
-    let content = match extension.as_str() {
-        "pdf" => extract_pdf_text(path)?,
-        "html" | "htm" => {
-            let html = fs::read_to_string(path).map_err(|e| AppError::File(e.to_string()))?;
-            strip_html_tags(&html)
+/// Read and extract a document's text. `max_chars = Some(n)` truncates for
+/// inline display; `None` returns the full text (used by the indexer so we
+/// don't drop content before chunking). The blocking fs read + PDF parse run
+/// off the async runtime via spawn_blocking so they don't stall other commands.
+pub async fn read_document_text(file_path: String, max_chars: Option<usize>) -> Result<String> {
+    let content = tauri::async_runtime::spawn_blocking(move || -> Result<String> {
+        // Reject obvious traversal patterns. We cannot meaningfully sandbox the
+        // filesystem here (the user's own dialog picks arbitrary absolute paths)
+        // but we can still refuse paths whose components include `..`.
+        if file_path.split(['/', '\\']).any(|s| s == "..") {
+            return Err(AppError::File("Path traversal patterns are not allowed".to_string()));
         }
-        _ => {
-            // Text-based formats. Use lossy UTF-8 for files that contain mixed
-            // encodings (e.g. log files) so we still surface readable content.
-            let bytes = fs::read(path).map_err(|e| AppError::File(e.to_string()))?;
-            String::from_utf8(bytes.clone()).unwrap_or_else(|_| String::from_utf8_lossy(&bytes).into_owned())
-        }
-    };
 
-    // Truncate if too long (to avoid token limits)
-    let max_chars = 100_000;
-    if content.len() > max_chars {
-        // Find a valid UTF-8 boundary at or before max_chars
-        let truncated = match content.char_indices().nth(max_chars) {
-            Some((byte_idx, _)) => &content[..byte_idx],
-            None => &content, // fewer than max_chars characters
-        };
-        Ok(format!("{}...\n\n[Content truncated - showing first {} characters]", truncated, max_chars))
-    } else {
-        Ok(content)
+        let path = Path::new(&file_path);
+        if !path.exists() {
+            return Err(AppError::File(format!("File not found: {}", file_path)));
+        }
+
+        let metadata = fs::metadata(path).map_err(|e| AppError::File(e.to_string()))?;
+        if !metadata.is_file() {
+            return Err(AppError::File("Path is not a regular file".to_string()));
+        }
+        if metadata.len() > MAX_DOCUMENT_BYTES {
+            return Err(AppError::File(format!(
+                "File too large ({} MB). Maximum supported size is {} MB.",
+                metadata.len() / 1_048_576,
+                MAX_DOCUMENT_BYTES / 1_048_576,
+            )));
+        }
+
+        let extension = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_lowercase();
+
+        if !is_allowed_extension(&extension) {
+            return Err(AppError::File(format!("Unsupported file type: .{}", extension)));
+        }
+
+        match extension.as_str() {
+            "pdf" => extract_pdf_text(path),
+            "html" | "htm" => {
+                let html = fs::read_to_string(path).map_err(|e| AppError::File(e.to_string()))?;
+                Ok(strip_html_tags(&html))
+            }
+            _ => {
+                // Text-based formats. Use lossy UTF-8 for files with mixed
+                // encodings (e.g. log files) so we still surface readable text.
+                let bytes = fs::read(path).map_err(|e| AppError::File(e.to_string()))?;
+                Ok(String::from_utf8(bytes.clone())
+                    .unwrap_or_else(|_| String::from_utf8_lossy(&bytes).into_owned()))
+            }
+        }
+    })
+    .await
+    .map_err(|e| AppError::File(format!("Document read task failed: {}", e)))??;
+
+    match max_chars {
+        Some(max) if content.len() > max => {
+            // Find a valid UTF-8 boundary at or before max chars.
+            let truncated = match content.char_indices().nth(max) {
+                Some((byte_idx, _)) => &content[..byte_idx],
+                None => &content,
+            };
+            Ok(format!(
+                "{}...\n\n[Content truncated - showing first {} characters]",
+                truncated, max
+            ))
+        }
+        _ => Ok(content),
     }
 }
 
@@ -166,8 +181,9 @@ pub async fn index_document(
     use crate::services::embedding::EmbeddingService;
     use crate::services::vector_store::{VectorStore, DocumentChunk};
     
-    // Read document content
-    let content = match read_document_content(file_path.clone()).await {
+    // Read the FULL document text for indexing (no display truncation) so we
+    // don't silently drop content before chunking.
+    let content = match read_document_text(file_path.clone(), None).await {
         Ok(c) => c,
         Err(e) => return Ok(IndexResult {
             document_id,

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -40,7 +40,26 @@ impl Serialize for AppError {
 
 impl From<reqwest::Error> for AppError {
     fn from(err: reqwest::Error) -> Self {
+        if err.is_timeout() {
+            return AppError::Network("Request timed out".to_string());
+        }
+        if err.is_connect() {
+            return AppError::Network("Could not connect to the provider".to_string());
+        }
         AppError::Network(err.to_string())
+    }
+}
+
+impl AppError {
+    /// Map a provider HTTP status to a specific error variant so the UI can
+    /// react (rate-limit vs auth vs generic). `context` is a human label like
+    /// "OpenAI".
+    pub fn for_status(status: u16, context: &str, body: &str) -> AppError {
+        match status {
+            401 | 403 => AppError::InvalidApiKey,
+            429 => AppError::RateLimited,
+            _ => AppError::Api(format!("{} error {}: {}", context, status, body)),
+        }
     }
 }
 

--- a/src-tauri/src/services/ai_client.rs
+++ b/src-tauri/src/services/ai_client.rs
@@ -94,7 +94,11 @@ impl AiClient {
         match self.provider.as_str() {
             "gemini" => self.stream_gemini_with_emitter(app, model, message, history, context).await,
             "glm" => self.stream_glm_with_emitter(app, model, message, history, context).await,
-            // Fallback to non-streaming for other providers
+            "openai" => self.stream_openai_with_emitter(app, model, message, history, context).await,
+            "ollama" => self.stream_ollama_with_emitter(app, model, message, history, context).await,
+            // Anthropic (and any unknown provider) falls back to a single
+            // buffered emission. Anthropic's event-based SSE is intentionally
+            // not streamed here to avoid a hard-to-verify parser regression.
             _ => {
                 use tauri::Emitter;
                 let response = self.chat_with_history(model, message, history, context).await?;
@@ -658,6 +662,152 @@ impl AiClient {
             "chunk": "",
             "done": true
         }));
+        Ok(())
+    }
+
+    /// Stream from OpenAI chat completions via SSE (same delta format as GLM).
+    async fn stream_openai_with_emitter(
+        &self,
+        app: &tauri::AppHandle,
+        model: &str,
+        message: &str,
+        history: &[ChatMessage],
+        context: Option<&str>,
+    ) -> Result<()> {
+        use futures::StreamExt;
+        use tauri::Emitter;
+
+        let mut messages = Vec::new();
+        let system_msg = if let Some(ctx) = context {
+            format!("You are a helpful assistant. Use the following document context to answer questions accurately:\n\n{}", ctx)
+        } else {
+            "You are a helpful assistant.".to_string()
+        };
+        messages.push(serde_json::json!({"role": "system", "content": system_msg}));
+        for msg in history {
+            messages.push(serde_json::json!({"role": &msg.role, "content": &msg.content}));
+        }
+        messages.push(serde_json::json!({"role": "user", "content": message}));
+
+        let body = serde_json::json!({
+            "model": model,
+            "messages": messages,
+            "temperature": 0.7,
+            "stream": true,
+        });
+
+        let response = self.streaming_client.post("https://api.openai.com/v1/chat/completions")
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| AppError::Network(self.redact(e.to_string())))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            return Err(AppError::for_status(status.as_u16(), "OpenAI", &self.redact(error_text)));
+        }
+
+        let mut stream = response.bytes_stream();
+        let mut buffer = String::new();
+        while let Some(chunk_result) = stream.next().await {
+            if STREAM_CANCELLED.load(Ordering::SeqCst) {
+                break;
+            }
+            let chunk = chunk_result.map_err(|e| AppError::Network(self.redact(e.to_string())))?;
+            buffer.push_str(&String::from_utf8_lossy(&chunk));
+            for line in buffer.lines().collect::<Vec<_>>() {
+                if let Some(data) = line.strip_prefix("data: ") {
+                    if data == "[DONE]" {
+                        continue;
+                    }
+                    if let Ok(json) = serde_json::from_str::<serde_json::Value>(data) {
+                        if let Some(content) = json["choices"][0]["delta"]["content"].as_str() {
+                            let _ = app.emit("chat-stream", serde_json::json!({ "chunk": content, "done": false }));
+                        }
+                    }
+                }
+            }
+            if let Some(last_newline) = buffer.rfind('\n') {
+                buffer = buffer[last_newline + 1..].to_string();
+            }
+        }
+        let _ = app.emit("chat-stream", serde_json::json!({ "chunk": "", "done": true }));
+        Ok(())
+    }
+
+    /// Stream from a local Ollama server. Ollama emits newline-delimited JSON
+    /// ({ message: { content }, done }), not SSE.
+    async fn stream_ollama_with_emitter(
+        &self,
+        app: &tauri::AppHandle,
+        model: &str,
+        message: &str,
+        history: &[ChatMessage],
+        context: Option<&str>,
+    ) -> Result<()> {
+        use futures::StreamExt;
+        use tauri::Emitter;
+
+        let base_url = self.base_url.as_deref().unwrap_or("http://localhost:11434");
+        let mut messages = Vec::new();
+        if let Some(ctx) = context {
+            messages.push(serde_json::json!({
+                "role": "system",
+                "content": format!("Use the following document context to answer questions:\n\n{}", ctx)
+            }));
+        }
+        for msg in history {
+            messages.push(serde_json::json!({"role": &msg.role, "content": &msg.content}));
+        }
+        messages.push(serde_json::json!({"role": "user", "content": message}));
+
+        let body = serde_json::json!({
+            "model": model,
+            "messages": messages,
+            "stream": true,
+        });
+
+        let response = self.streaming_client.post(format!("{}/api/chat", base_url))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| AppError::Network(self.redact(e.to_string())))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            return Err(AppError::for_status(status.as_u16(), "Ollama", &self.redact(error_text)));
+        }
+
+        let mut stream = response.bytes_stream();
+        let mut buffer = String::new();
+        while let Some(chunk_result) = stream.next().await {
+            if STREAM_CANCELLED.load(Ordering::SeqCst) {
+                break;
+            }
+            let chunk = chunk_result.map_err(|e| AppError::Network(self.redact(e.to_string())))?;
+            buffer.push_str(&String::from_utf8_lossy(&chunk));
+            // Process complete NDJSON lines, keep the trailing partial in buffer.
+            while let Some(nl) = buffer.find('\n') {
+                let line = buffer[..nl].trim().to_string();
+                buffer = buffer[nl + 1..].to_string();
+                if line.is_empty() {
+                    continue;
+                }
+                if let Ok(json) = serde_json::from_str::<serde_json::Value>(&line) {
+                    if let Some(content) = json["message"]["content"].as_str() {
+                        if !content.is_empty() {
+                            let _ = app.emit("chat-stream", serde_json::json!({ "chunk": content, "done": false }));
+                        }
+                    }
+                }
+            }
+        }
+        let _ = app.emit("chat-stream", serde_json::json!({ "chunk": "", "done": true }));
         Ok(())
     }
 }

--- a/src-tauri/src/services/vector_store.rs
+++ b/src-tauri/src/services/vector_store.rs
@@ -39,7 +39,13 @@ impl VectorStore {
         
         let conn = Connection::open(&db_path)
             .map_err(|e| AppError::Database(format!("Failed to open database: {}", e)))?;
-        
+
+        // WAL allows concurrent readers while a writer is active and survives
+        // the fresh-connection-per-command pattern; busy_timeout avoids
+        // "database is locked" errors when indexing and searching overlap.
+        let _ = conn.pragma_update(None, "journal_mode", "WAL");
+        let _ = conn.pragma_update(None, "busy_timeout", 5000);
+
         // Initialize schema
         conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS chunks (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import {
   isGenerating,
   isFullscreen,
   isShortcutsHelpOpen,
+  isOnline,
   loadPersistedData,
   applyThemeClasses,
   flushPendingSaves,
@@ -53,6 +54,12 @@ export function App() {
     };
     window.addEventListener("beforeunload", handleUnload);
     window.addEventListener("pagehide", handleUnload);
+
+    // Track connectivity so the UI can show an Offline pill and block cloud sends.
+    const handleOnline = () => { isOnline.value = true; };
+    const handleOffline = () => { isOnline.value = false; };
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
 
     const handleKeyDown = async (e: KeyboardEvent) => {
       // Command Palette (Ctrl+K)
@@ -174,6 +181,8 @@ export function App() {
       window.removeEventListener("keydown", handleKeyDown);
       window.removeEventListener("beforeunload", handleUnload);
       window.removeEventListener("pagehide", handleUnload);
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
       document.removeEventListener("contextmenu", handleContextMenu);
     };
   }, []);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,6 @@ import {
   isCommandPaletteOpen,
   isCompareMode,
   currentMessages,
-  activeSessionId,
-  chatHistory,
   stopGeneration,
   isGenerating,
   isFullscreen,
@@ -16,6 +14,9 @@ import {
   loadPersistedData,
   applyThemeClasses,
   flushPendingSaves,
+  startNewChat,
+  loadSessionByIndex,
+  loadAdjacentSession,
 } from "./stores/appStore";
 import { Spotlight } from "./components/spotlight/Spotlight";
 import { Dashboard } from "./components/dashboard/Dashboard";
@@ -64,8 +65,7 @@ export function App() {
       // New Chat (Ctrl+N)
       if (e.key === "n" && (e.ctrlKey || e.metaKey)) {
         e.preventDefault();
-        currentMessages.value = [];
-        activeSessionId.value = null;
+        startNewChat();
         return;
       }
 
@@ -106,39 +106,21 @@ export function App() {
       // Quick Chat Navigation (Ctrl+1-9)
       if ((e.ctrlKey || e.metaKey) && e.key >= "1" && e.key <= "9") {
         e.preventDefault();
-        const index = parseInt(e.key) - 1;
-        if (chatHistory.value[index]) {
-          currentMessages.value = chatHistory.value[index].messages;
-          activeSessionId.value = chatHistory.value[index].id;
-        }
+        loadSessionByIndex(parseInt(e.key) - 1);
         return;
       }
 
       // Previous Chat (Ctrl+[)
       if (e.key === "[" && (e.ctrlKey || e.metaKey)) {
         e.preventDefault();
-        if (activeSessionId.value) {
-          const currentIndex = chatHistory.value.findIndex(s => s.id === activeSessionId.value);
-          if (currentIndex > 0) {
-            const prevSession = chatHistory.value[currentIndex - 1];
-            currentMessages.value = prevSession.messages;
-            activeSessionId.value = prevSession.id;
-          }
-        }
+        loadAdjacentSession(-1);
         return;
       }
 
       // Next Chat (Ctrl+])
       if (e.key === "]" && (e.ctrlKey || e.metaKey)) {
         e.preventDefault();
-        if (activeSessionId.value) {
-          const currentIndex = chatHistory.value.findIndex(s => s.id === activeSessionId.value);
-          if (currentIndex < chatHistory.value.length - 1) {
-            const nextSession = chatHistory.value[currentIndex + 1];
-            currentMessages.value = nextSession.messages;
-            activeSessionId.value = nextSession.id;
-          }
-        }
+        loadAdjacentSession(1);
         return;
       }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from "preact/hooks";
 import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+import { toast } from "./stores/toastStore";
 import {
   viewMode,
   theme,
@@ -12,6 +14,8 @@ import {
   isFullscreen,
   isShortcutsHelpOpen,
   isOnline,
+  isDragOver,
+  addDroppedFiles,
   loadPersistedData,
   applyThemeClasses,
   flushPendingSaves,
@@ -60,6 +64,26 @@ export function App() {
     const handleOffline = () => { isOnline.value = false; };
     window.addEventListener("online", handleOnline);
     window.addEventListener("offline", handleOffline);
+
+    // OS-level file drag-and-drop → add as documents (the feature the
+    // onboarding tour advertises). Shows a drop overlay while hovering.
+    let unlistenDrop: (() => void) | undefined;
+    getCurrentWebview()
+      .onDragDropEvent((event) => {
+        const p = event.payload as { type: string; paths?: string[] };
+        if (p.type === "enter" || p.type === "over") {
+          isDragOver.value = true;
+        } else if (p.type === "leave") {
+          isDragOver.value = false;
+        } else if (p.type === "drop") {
+          isDragOver.value = false;
+          const n = addDroppedFiles(p.paths ?? []);
+          if (n > 0) toast.success(`Added ${n} document${n > 1 ? "s" : ""}`);
+          else toast.warning("No supported files in that drop");
+        }
+      })
+      .then((fn) => { unlistenDrop = fn; })
+      .catch(() => {});
 
     const handleKeyDown = async (e: KeyboardEvent) => {
       // Command Palette (Ctrl+K)
@@ -183,6 +207,7 @@ export function App() {
       window.removeEventListener("pagehide", handleUnload);
       window.removeEventListener("online", handleOnline);
       window.removeEventListener("offline", handleOffline);
+      unlistenDrop?.();
       document.removeEventListener("contextmenu", handleContextMenu);
     };
   }, []);
@@ -201,6 +226,14 @@ export function App() {
       <ToastContainer />
       <KeyboardShortcuts />
       <Onboarding />
+      {isDragOver.value && (
+        <div className="fixed inset-0 z-[300] flex items-center justify-center bg-accent-primary/10 backdrop-blur-sm border-4 border-dashed border-accent-primary pointer-events-none">
+          <div className="text-center px-6 py-4 rounded-xl bg-bg-primary/90 border border-border shadow-2xl">
+            <p className="text-lg font-semibold text-text-primary">Drop files to add as documents</p>
+            <p className="text-sm text-text-secondary mt-1">PDF, text, markdown, code, and more</p>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/common/BranchSelector.tsx
+++ b/src/components/common/BranchSelector.tsx
@@ -68,6 +68,9 @@ export function BranchSelector({ className = "" }: BranchSelectorProps) {
             {/* Dropdown Trigger */}
             <button
                 onClick={() => setIsOpen(!isOpen)}
+                aria-haspopup="true"
+                aria-expanded={isOpen}
+                aria-label={`Branch ${branchInfo.name}, ${branchInfo.index + 1} of ${branchInfo.total}. Switch branch`}
                 className="flex items-center gap-1.5 px-2.5 py-1.5 bg-bg-tertiary hover:bg-bg-tertiary/80 rounded-lg text-xs text-text-secondary transition-colors border border-transparent hover:border-border"
             >
                 <BranchIcon size={12} />
@@ -86,12 +89,29 @@ export function BranchSelector({ className = "" }: BranchSelectorProps) {
                     />
 
                     {/* Menu */}
-                    <div className="absolute top-full left-1/2 -translate-x-1/2 mt-1 z-20 min-w-[180px] bg-bg-secondary border border-border rounded-lg shadow-lg overflow-hidden">
+                    <div
+                        role="menu"
+                        aria-label="Conversation branches"
+                        className="absolute top-full left-1/2 -translate-x-1/2 mt-1 z-20 min-w-[180px] bg-bg-secondary border border-border rounded-lg shadow-lg overflow-hidden"
+                    >
                         {branches.map((branch) => (
                             <div
                                 key={branch.id ?? "main"}
+                                role="menuitemradio"
+                                aria-checked={branch.isActive}
+                                tabIndex={0}
                                 onClick={() => handleSelect(branch.id)}
-                                className={`group flex items-center justify-between gap-2 px-3 py-2 text-xs transition-colors cursor-pointer
+                                onKeyDown={(e) => {
+                                    if (editingId) return;
+                                    if (e.key === "Enter" || e.key === " ") {
+                                        e.preventDefault();
+                                        handleSelect(branch.id);
+                                    } else if (e.key === "Escape") {
+                                        setIsOpen(false);
+                                        setEditingId(null);
+                                    }
+                                }}
+                                className={`group flex items-center justify-between gap-2 px-3 py-2 text-xs transition-colors cursor-pointer outline-none focus-visible:bg-bg-tertiary
                   ${branch.isActive
                                         ? "bg-accent-primary/10 text-accent-primary"
                                         : "text-text-secondary hover:bg-bg-tertiary"
@@ -125,6 +145,7 @@ export function BranchSelector({ className = "" }: BranchSelectorProps) {
                                                 onClick={(e) => handleStartRename(e, branch.id!, branch.name)}
                                                 className="opacity-0 group-hover:opacity-100 p-0.5 hover:text-accent-primary rounded transition-opacity"
                                                 title="Rename"
+                                                aria-label={`Rename branch ${branch.name}`}
                                             >
                                                 <EditIcon size={10} />
                                             </button>
@@ -132,6 +153,7 @@ export function BranchSelector({ className = "" }: BranchSelectorProps) {
                                                 onClick={(e) => handleDelete(e, branch.id!)}
                                                 className="opacity-0 group-hover:opacity-100 p-0.5 hover:text-error rounded transition-opacity"
                                                 title="Delete"
+                                                aria-label={`Delete branch ${branch.name}`}
                                             >
                                                 <CloseIcon size={10} />
                                             </button>

--- a/src/components/common/CommandPalette.tsx
+++ b/src/components/common/CommandPalette.tsx
@@ -5,8 +5,8 @@ import {
     searchChatHistory,
     searchResults,
     chatHistory,
-    currentMessages,
-    activeSessionId,
+    loadSession,
+    startNewChat,
     viewMode,
     isSettingsOpen,
     isCompareMode,
@@ -47,8 +47,7 @@ export function CommandPalette() {
             category: "action",
             keywords: ["create", "start", "conversation"],
             action: () => {
-                currentMessages.value = [];
-                activeSessionId.value = null;
+                startNewChat();
                 isCommandPaletteOpen.value = false;
             },
         },
@@ -116,8 +115,7 @@ export function CommandPalette() {
         icon: <MessageIcon size={16} />,
         category: "navigation" as const,
         action: () => {
-            currentMessages.value = session.messages;
-            activeSessionId.value = session.id;
+            loadSession(session);
             isCommandPaletteOpen.value = false;
         },
     }));
@@ -189,8 +187,7 @@ export function CommandPalette() {
                     const result = searchResults.value[selectedIndex];
                     const session = chatHistory.value.find(s => s.id === result.sessionId);
                     if (session) {
-                        currentMessages.value = session.messages;
-                        activeSessionId.value = session.id;
+                        loadSession(session);
                         isCommandPaletteOpen.value = false;
                     }
                 }
@@ -326,8 +323,7 @@ export function CommandPalette() {
                                             onClick={() => {
                                                 const session = chatHistory.value.find(s => s.id === result.sessionId);
                                                 if (session) {
-                                                    currentMessages.value = session.messages;
-                                                    activeSessionId.value = session.id;
+                                                    loadSession(session);
                                                     isCommandPaletteOpen.value = false;
                                                 }
                                             }}

--- a/src/components/common/CommandPalette.tsx
+++ b/src/components/common/CommandPalette.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "preact/hooks";
+import { useFocusTrap } from "../../hooks/useFocusTrap";
 import {
     isCommandPaletteOpen,
     commandPaletteQuery,
@@ -35,8 +36,11 @@ interface Command {
 
 export function CommandPalette() {
     const inputRef = useRef<HTMLInputElement>(null);
+    const panelRef = useRef<HTMLDivElement>(null);
     const [selectedIndex, setSelectedIndex] = useState(0);
     const [mode, setMode] = useState<"commands" | "search">("commands");
+    // Trap + restore focus (Escape is handled by the component's own keydown).
+    useFocusTrap(panelRef, isCommandPaletteOpen.value);
 
     const commands: Command[] = [
         {
@@ -217,6 +221,7 @@ export function CommandPalette() {
             aria-label="Command Palette"
         >
             <div
+                ref={panelRef}
                 className="w-full max-w-xl bg-bg-primary border border-border rounded-xl shadow-2xl overflow-hidden animate-scale-in"
                 onClick={(e) => e.stopPropagation()}
             >
@@ -245,6 +250,7 @@ export function CommandPalette() {
                     <button
                         onClick={() => (isCommandPaletteOpen.value = false)}
                         className="p-1 rounded hover:bg-bg-tertiary text-text-tertiary hover:text-text-primary"
+                        aria-label="Close command palette"
                     >
                         <CloseIcon size={14} />
                     </button>

--- a/src/components/common/CommandPalette.tsx
+++ b/src/components/common/CommandPalette.tsx
@@ -37,10 +37,17 @@ interface Command {
 export function CommandPalette() {
     const inputRef = useRef<HTMLInputElement>(null);
     const panelRef = useRef<HTMLDivElement>(null);
+    const resultsRef = useRef<HTMLDivElement>(null);
     const [selectedIndex, setSelectedIndex] = useState(0);
     const [mode, setMode] = useState<"commands" | "search">("commands");
     // Trap + restore focus (Escape is handled by the component's own keydown).
     useFocusTrap(panelRef, isCommandPaletteOpen.value);
+
+    // Keep the keyboard-selected row scrolled into view.
+    useEffect(() => {
+        const el = resultsRef.current?.querySelector(`[data-cmd-index="${selectedIndex}"]`) as HTMLElement | null;
+        el?.scrollIntoView({ block: "nearest" });
+    }, [selectedIndex]);
 
     const commands: Command[] = [
         {
@@ -257,7 +264,7 @@ export function CommandPalette() {
                 </div>
 
                 {/* Results */}
-                <div className="max-h-80 overflow-y-auto">
+                <div ref={resultsRef} className="max-h-80 overflow-y-auto">
                     {mode === "commands" ? (
                         <>
                             {/* Commands Section */}
@@ -267,6 +274,7 @@ export function CommandPalette() {
                                     {filteredCommands.map((cmd, idx) => (
                                         <button
                                             key={cmd.id}
+                                            data-cmd-index={idx}
                                             onClick={() => cmd.action()}
                                             className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left transition-colors ${selectedIndex === idx
                                                     ? "bg-accent-primary/10 text-accent-primary"
@@ -293,6 +301,7 @@ export function CommandPalette() {
                                     {filteredRecentChats.map((chat, idx) => (
                                         <button
                                             key={chat.id}
+                                            data-cmd-index={filteredCommands.length + idx}
                                             onClick={() => chat.action()}
                                             className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left transition-colors ${selectedIndex === filteredCommands.length + idx
                                                     ? "bg-accent-primary/10 text-accent-primary"
@@ -326,6 +335,7 @@ export function CommandPalette() {
                                     {searchResults.value.map((result, idx) => (
                                         <button
                                             key={`${result.sessionId}-${result.messageId}`}
+                                            data-cmd-index={idx}
                                             onClick={() => {
                                                 const session = chatHistory.value.find(s => s.id === result.sessionId);
                                                 if (session) {

--- a/src/components/common/ExportImport.tsx
+++ b/src/components/common/ExportImport.tsx
@@ -3,6 +3,7 @@ import { useFocusTrap } from "../../hooks/useFocusTrap";
 import {
     exportSession,
     importSession,
+    importAllSessions,
     chatHistory,
     ChatSession,
 } from "../../stores/appStore";
@@ -29,7 +30,22 @@ export function ExportImport({ session, onClose }: ExportImportProps) {
     const [copied, setCopied] = useState(false);
     const [selectedBranch, setSelectedBranch] = useState<string | null>(null); // null = main
     const panelRef = useRef<HTMLDivElement>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
     useFocusTrap(panelRef, true, onClose);
+
+    const handleFile = async (e: Event) => {
+        const input = e.target as HTMLInputElement;
+        const file = input.files?.[0];
+        if (!file) return;
+        try {
+            const text = await file.text();
+            setImportText(text);
+            setImportResult(null);
+        } catch {
+            setImportResult("error");
+        }
+        input.value = "";
+    };
 
     // Get branches for current session
     const getBranches = () => {
@@ -73,13 +89,20 @@ export function ExportImport({ session, onClose }: ExportImportProps) {
     };
 
     const handleImport = () => {
+        // Try the full-backup envelope first (version/sessions/folders), then
+        // fall back to a single-session import.
+        const bulk = importAllSessions(importText);
+        if (bulk !== null) {
+            setImportResult("success");
+            setImportText("");
+            setTimeout(() => { onClose?.(); }, 1500);
+            return;
+        }
         const result = importSession(importText);
         if (result) {
             setImportResult("success");
             setImportText("");
-            setTimeout(() => {
-                onClose?.();
-            }, 1500);
+            setTimeout(() => { onClose?.(); }, 1500);
         } else {
             setImportResult("error");
         }
@@ -241,9 +264,26 @@ export function ExportImport({ session, onClose }: ExportImportProps) {
                     ) : (
                         <div className="space-y-4">
                             <div>
-                                <label className="text-sm text-text-secondary mb-2 block">
-                                    Paste JSON export
-                                </label>
+                                <div className="flex items-center justify-between mb-2">
+                                    <label className="text-sm text-text-secondary">
+                                        Paste JSON, or import a file
+                                    </label>
+                                    <button
+                                        onClick={() => fileInputRef.current?.click()}
+                                        className="flex items-center gap-1.5 px-2.5 py-1 text-xs bg-bg-secondary border border-border rounded hover:bg-bg-tertiary text-text-secondary"
+                                    >
+                                        <UploadIcon size={12} />
+                                        Choose file…
+                                    </button>
+                                    <input
+                                        ref={fileInputRef}
+                                        type="file"
+                                        accept=".json,application/json"
+                                        onChange={handleFile}
+                                        className="hidden"
+                                        aria-hidden="true"
+                                    />
+                                </div>
                                 <textarea
                                     value={importText}
                                     onInput={(e) => {

--- a/src/components/common/ExportImport.tsx
+++ b/src/components/common/ExportImport.tsx
@@ -1,4 +1,5 @@
-import { useState } from "preact/hooks";
+import { useState, useRef } from "preact/hooks";
+import { useFocusTrap } from "../../hooks/useFocusTrap";
 import {
     exportSession,
     importSession,
@@ -27,6 +28,8 @@ export function ExportImport({ session, onClose }: ExportImportProps) {
     const [exportContent, setExportContent] = useState("");
     const [copied, setCopied] = useState(false);
     const [selectedBranch, setSelectedBranch] = useState<string | null>(null); // null = main
+    const panelRef = useRef<HTMLDivElement>(null);
+    useFocusTrap(panelRef, true, onClose);
 
     // Get branches for current session
     const getBranches = () => {
@@ -83,8 +86,15 @@ export function ExportImport({ session, onClose }: ExportImportProps) {
     };
 
     return (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm">
-            <div className="w-full max-w-lg bg-bg-primary border border-border rounded-xl shadow-2xl overflow-hidden">
+        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm" onClick={onClose}>
+            <div
+                ref={panelRef}
+                role="dialog"
+                aria-modal="true"
+                aria-label="Export or import chat"
+                onClick={(e) => e.stopPropagation()}
+                className="w-full max-w-lg bg-bg-primary border border-border rounded-xl shadow-2xl overflow-hidden"
+            >
                 {/* Header */}
                 <div className="flex items-center justify-between px-4 py-3 border-b border-border">
                     <div className="flex items-center gap-3">
@@ -92,7 +102,7 @@ export function ExportImport({ session, onClose }: ExportImportProps) {
                             <button
                                 onClick={() => setMode("export")}
                                 className={`px-3 py-1.5 text-sm flex items-center gap-1.5 ${mode === "export"
-                                    ? "bg-accent-primary text-white"
+                                    ? "bg-accent-primary text-on-accent"
                                     : "bg-bg-secondary text-text-secondary hover:bg-bg-tertiary"
                                     }`}
                             >
@@ -102,7 +112,7 @@ export function ExportImport({ session, onClose }: ExportImportProps) {
                             <button
                                 onClick={() => setMode("import")}
                                 className={`px-3 py-1.5 text-sm flex items-center gap-1.5 ${mode === "import"
-                                    ? "bg-accent-primary text-white"
+                                    ? "bg-accent-primary text-on-accent"
                                     : "bg-bg-secondary text-text-secondary hover:bg-bg-tertiary"
                                     }`}
                             >
@@ -114,6 +124,7 @@ export function ExportImport({ session, onClose }: ExportImportProps) {
                     <button
                         onClick={onClose}
                         className="p-1.5 hover:bg-bg-tertiary rounded text-text-tertiary hover:text-text-primary"
+                        aria-label="Close export dialog"
                     >
                         <CloseIcon size={16} />
                     </button>
@@ -194,7 +205,7 @@ export function ExportImport({ session, onClose }: ExportImportProps) {
                             {session && !exportContent && (
                                 <button
                                     onClick={handleExport}
-                                    className="w-full px-4 py-2 bg-accent-primary text-white rounded-lg hover:bg-accent-primary/90 text-sm font-medium"
+                                    className="w-full px-4 py-2 bg-accent-primary text-on-accent rounded-lg hover:bg-accent-primary/90 text-sm font-medium"
                                 >
                                     Generate Export
                                 </button>
@@ -214,7 +225,7 @@ export function ExportImport({ session, onClose }: ExportImportProps) {
                                             </button>
                                             <button
                                                 onClick={handleDownload}
-                                                className="px-3 py-1.5 text-xs bg-accent-primary text-white rounded hover:bg-accent-primary/90"
+                                                className="px-3 py-1.5 text-xs bg-accent-primary text-on-accent rounded hover:bg-accent-primary/90"
                                             >
                                                 Download
                                             </button>
@@ -262,7 +273,7 @@ export function ExportImport({ session, onClose }: ExportImportProps) {
                                 onClick={handleImport}
                                 disabled={!importText.trim()}
                                 className={`w-full px-4 py-2 rounded-lg text-sm font-medium ${importText.trim()
-                                    ? "bg-accent-primary text-white hover:bg-accent-primary/90"
+                                    ? "bg-accent-primary text-on-accent hover:bg-accent-primary/90"
                                     : "bg-bg-tertiary text-text-tertiary cursor-not-allowed"
                                     }`}
                             >

--- a/src/components/common/FolderManager.tsx
+++ b/src/components/common/FolderManager.tsx
@@ -9,7 +9,6 @@ import {
     updateSessionFolder,
     ChatFolder,
     activeSessionId,
-    currentMessages,
 } from "../../stores/appStore";
 import {
     FolderIcon,
@@ -144,7 +143,7 @@ export function FolderManager({ onSelectSession }: FolderManagerProps) {
                         />
                         <button
                             onClick={handleAddFolder}
-                            className="p-1.5 bg-accent-primary text-white rounded hover:bg-accent-primary/90"
+                            className="p-1.5 bg-accent-primary text-on-accent rounded hover:bg-accent-primary/90"
                         >
                             <CheckIcon size={12} />
                         </button>
@@ -171,7 +170,7 @@ export function FolderManager({ onSelectSession }: FolderManagerProps) {
                         </p>
                         <button
                             onClick={() => setIsAddingFolder(true)}
-                            className="inline-flex items-center gap-1 px-3 py-1.5 rounded bg-accent-primary text-white text-xs hover:bg-accent-primary/90 transition-colors"
+                            className="inline-flex items-center gap-1 px-3 py-1.5 rounded bg-accent-primary text-on-accent text-xs hover:bg-accent-primary/90 transition-colors"
                         >
                             <PlusIcon size={12} />
                             New folder
@@ -223,12 +222,12 @@ export function FolderManager({ onSelectSession }: FolderManagerProps) {
                                 key={session.id}
                                 draggable
                                 onDragStart={(e) => handleDragStart(session.id, e)}
-                                onClick={() => {
-                                    currentMessages.value = session.messages;
-                                    activeSessionId.value = session.id;
-                                    onSelectSession(session.id);
-                                }}
-                                className={`px-3 py-2 cursor-grab active:cursor-grabbing transition-colors ${activeSessionId.value === session.id
+                                onClick={() => onSelectSession(session.id)}
+                                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onSelectSession(session.id); } }}
+                                role="button"
+                                tabIndex={0}
+                                aria-label={`Open chat ${session.title}`}
+                                className={`px-3 py-2 cursor-grab active:cursor-grabbing transition-colors outline-none focus-visible:bg-bg-tertiary ${activeSessionId.value === session.id
                                     ? "bg-accent-primary/10 text-accent-primary"
                                     : "hover:bg-bg-tertiary text-text-primary"
                                     }`}
@@ -373,11 +372,12 @@ function FolderItem({
                                 key={session.id}
                                 draggable
                                 onDragStart={(e) => onSessionDragStart(session.id, e)}
-                                onClick={() => {
-                                    currentMessages.value = session.messages;
-                                    onSelectSession(session.id);
-                                }}
-                                className={`px-2 py-1.5 rounded cursor-pointer transition-colors ${activeSessionId === session.id
+                                onClick={() => onSelectSession(session.id)}
+                                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onSelectSession(session.id); } }}
+                                role="button"
+                                tabIndex={0}
+                                aria-label={`Open chat ${session.title}`}
+                                className={`px-2 py-1.5 rounded cursor-pointer transition-colors outline-none focus-visible:bg-bg-tertiary ${activeSessionId === session.id
                                     ? "bg-accent-primary/10 text-accent-primary"
                                     : "hover:bg-bg-tertiary text-text-primary"
                                     }`}

--- a/src/components/common/KeyboardShortcuts.tsx
+++ b/src/components/common/KeyboardShortcuts.tsx
@@ -1,4 +1,6 @@
+import { useRef } from "preact/hooks";
 import { isShortcutsHelpOpen, viewMode } from "../../stores/appStore";
+import { useFocusTrap } from "../../hooks/useFocusTrap";
 import { CloseIcon, CommandIcon } from "../icons";
 
 interface ShortcutGroup {
@@ -67,6 +69,9 @@ const fullShortcutGroups: ShortcutGroup[] = [
 ];
 
 export function KeyboardShortcuts() {
+    const panelRef = useRef<HTMLDivElement>(null);
+    useFocusTrap(panelRef, isShortcutsHelpOpen.value);
+
     if (!isShortcutsHelpOpen.value) return null;
 
     const isSpotlight = viewMode.value === "spotlight";
@@ -80,6 +85,10 @@ export function KeyboardShortcuts() {
                 onClick={() => (isShortcutsHelpOpen.value = false)}
             >
                 <div
+                    ref={panelRef}
+                    role="dialog"
+                    aria-modal="true"
+                    aria-label="Keyboard shortcuts"
                     className="m-2 bg-bg-primary border border-border rounded-lg shadow-2xl overflow-hidden flex flex-col"
                     style={{ maxHeight: 'calc(100% - 16px)' }}
                     onClick={(e) => e.stopPropagation()}
@@ -93,6 +102,7 @@ export function KeyboardShortcuts() {
                         <button
                             onClick={() => (isShortcutsHelpOpen.value = false)}
                             className="p-1 hover:bg-bg-tertiary rounded text-text-tertiary hover:text-text-primary"
+                            aria-label="Close shortcuts"
                         >
                             <CloseIcon size={12} />
                         </button>
@@ -143,6 +153,10 @@ export function KeyboardShortcuts() {
             onClick={() => (isShortcutsHelpOpen.value = false)}
         >
             <div
+                ref={panelRef}
+                role="dialog"
+                aria-modal="true"
+                aria-label="Keyboard shortcuts"
                 className="w-full max-w-xl bg-bg-primary border border-border rounded-xl shadow-2xl overflow-hidden animate-scale-in"
                 onClick={(e) => e.stopPropagation()}
             >
@@ -160,6 +174,7 @@ export function KeyboardShortcuts() {
                     <button
                         onClick={() => (isShortcutsHelpOpen.value = false)}
                         className="p-2 hover:bg-bg-tertiary rounded-lg transition-colors text-text-tertiary hover:text-text-primary"
+                        aria-label="Close shortcuts"
                     >
                         <CloseIcon size={18} />
                     </button>

--- a/src/components/common/ModelCompare.tsx
+++ b/src/components/common/ModelCompare.tsx
@@ -2,6 +2,7 @@ import { useState, useRef } from "preact/hooks";
 import { invoke } from "@tauri-apps/api/core";
 import { listen, UnlistenFn } from "@tauri-apps/api/event";
 import { providers } from "../../stores/appStore";
+import { useFocusTrap } from "../../hooks/useFocusTrap";
 import {
     CompareIcon,
     CloseIcon,
@@ -56,6 +57,8 @@ export function ModelCompare({ onClose }: ModelCompareProps) {
     const [isComparing, setIsComparing] = useState(false);
     const [hasCompared, setHasCompared] = useState(false);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const panelRef = useRef<HTMLDivElement>(null);
+    useFocusTrap(panelRef, true, onClose);
 
     const addModel = (provider: string, model: string) => {
         if (selectedModels.length >= 4) return;
@@ -183,8 +186,15 @@ export function ModelCompare({ onClose }: ModelCompareProps) {
     const completedResponses = responses.filter(r => !r.isLoading && !r.error && r.content);
 
     return (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
-            <div className="w-full max-w-7xl h-[85vh] bg-bg-primary border border-border rounded-xl shadow-2xl overflow-hidden flex flex-col animate-fade-in">
+        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4" onClick={onClose}>
+            <div
+                ref={panelRef}
+                role="dialog"
+                aria-modal="true"
+                aria-label="Model comparison"
+                onClick={(e) => e.stopPropagation()}
+                className="w-full max-w-7xl h-[85vh] bg-bg-primary border border-border rounded-xl shadow-2xl overflow-hidden flex flex-col animate-fade-in"
+            >
                 {/* Header */}
                 <div className="flex items-center justify-between px-5 py-3 border-b border-border bg-bg-secondary">
                     <div className="flex items-center gap-3">
@@ -218,6 +228,7 @@ export function ModelCompare({ onClose }: ModelCompareProps) {
                         <button
                             onClick={onClose}
                             className="p-1.5 hover:bg-bg-tertiary rounded-lg text-text-tertiary hover:text-text-primary transition-colors"
+                            aria-label="Close model comparison"
                         >
                             <CloseIcon size={18} />
                         </button>
@@ -242,6 +253,7 @@ export function ModelCompare({ onClose }: ModelCompareProps) {
                                     <button
                                         onClick={() => removeModel(index)}
                                         className={`${colors.text} opacity-60 hover:opacity-100 transition-opacity`}
+                                        aria-label={`Remove ${model.model}`}
                                     >
                                         <CloseIcon size={12} />
                                     </button>
@@ -273,7 +285,7 @@ export function ModelCompare({ onClose }: ModelCompareProps) {
                             onClick={handleCompare}
                             disabled={!prompt.trim() || selectedModels.length < 2 || isComparing}
                             className={`px-5 py-3 rounded-xl font-medium flex items-center gap-2 transition-all ${prompt.trim() && selectedModels.length >= 2 && !isComparing
-                                ? "bg-accent-primary text-white hover:bg-accent-primary/90 shadow-lg shadow-accent-primary/20"
+                                ? "bg-accent-primary text-on-accent hover:bg-accent-primary/90 shadow-lg shadow-accent-primary/20"
                                 : "bg-bg-tertiary text-text-tertiary cursor-not-allowed"
                                 }`}
                         >
@@ -371,6 +383,7 @@ export function ModelCompare({ onClose }: ModelCompareProps) {
                                                         onClick={() => handleCopyResponse(response.content)}
                                                         className="p-1 rounded hover:bg-bg-tertiary text-text-tertiary hover:text-text-primary transition-colors"
                                                         title="Copy response"
+                                                        aria-label="Copy response"
                                                     >
                                                         <CopyIcon size={12} />
                                                     </button>

--- a/src/components/common/ModelSelector.tsx
+++ b/src/components/common/ModelSelector.tsx
@@ -1,4 +1,4 @@
-import { useState } from "preact/hooks";
+import { useState, useRef, useEffect } from "preact/hooks";
 import {
   activeModel,
   activeProvider,
@@ -28,6 +28,7 @@ interface ModelSelectorProps {
 export function ModelSelector({ compact = false }: ModelSelectorProps) {
   const [open, setOpen] = useState(false);
   const ref = useClickOutside<HTMLDivElement>(() => setOpen(false), open);
+  const listRef = useRef<HTMLDivElement>(null);
 
   const currentProvider = providers.value.find(p => p.id === activeProvider.value);
   const currentProviderLabel = currentProvider?.name.replace(" (Local)", "") ?? activeProvider.value;
@@ -37,8 +38,20 @@ export function ModelSelector({ compact = false }: ModelSelectorProps) {
     setOpen(false);
   };
 
+  // Scroll the active model into view when the dropdown opens.
+  useEffect(() => {
+    if (open) {
+      const el = listRef.current?.querySelector('[aria-selected="true"]') as HTMLElement | null;
+      el?.scrollIntoView({ block: "nearest" });
+    }
+  }, [open]);
+
   return (
-    <div className="relative" ref={ref}>
+    <div
+      className="relative"
+      ref={ref}
+      onKeyDown={(e) => { if (e.key === "Escape") setOpen(false); }}
+    >
       <button
         onClick={() => setOpen(o => !o)}
         aria-haspopup="listbox"
@@ -70,6 +83,7 @@ export function ModelSelector({ compact = false }: ModelSelectorProps) {
 
       {open && (
         <div
+          ref={listRef}
           role="listbox"
           aria-label="Available AI models"
           className={`absolute top-full left-0 mt-1 bg-bg-primary border border-border rounded-lg shadow-xl z-50 py-1 overflow-y-auto ${

--- a/src/components/common/Onboarding.tsx
+++ b/src/components/common/Onboarding.tsx
@@ -1,9 +1,10 @@
-import { useState } from "preact/hooks";
+import { useState, useRef } from "preact/hooks";
 import {
     isOnboardingActive,
     hasCompletedOnboarding,
     isSettingsOpen,
 } from "../../stores/appStore";
+import { useFocusTrap } from "../../hooks/useFocusTrap";
 import { LogoIcon, ChevronDownIcon, CommandIcon } from "../icons";
 import { toast } from "../../stores/toastStore";
 
@@ -32,7 +33,10 @@ const steps: OnboardingStep[] = [
                 <span className="text-2xl">🔑</span>
             </div>
         ),
-        action: () => { isSettingsOpen.value = true; isOnboardingActive.value = false; },
+        // Open Settings but keep the tour active so the user returns to it
+        // after adding a key (previously this dismissed onboarding without
+        // persisting completion, so the tour re-appeared every launch).
+        action: () => { isSettingsOpen.value = true; },
         actionLabel: "Open Settings",
     },
     {
@@ -69,6 +73,8 @@ const steps: OnboardingStep[] = [
 
 export function Onboarding() {
     const [currentStep, setCurrentStep] = useState(0);
+    const panelRef = useRef<HTMLDivElement>(null);
+    useFocusTrap(panelRef, isOnboardingActive.value, () => completeOnboarding());
 
     if (!isOnboardingActive.value) return null;
 
@@ -83,11 +89,15 @@ export function Onboarding() {
         }
     };
 
+    const handleBack = () => {
+        if (currentStep > 0) setCurrentStep(currentStep - 1);
+    };
+
     const handleSkip = () => {
         completeOnboarding();
     };
 
-    const completeOnboarding = () => {
+    function completeOnboarding() {
         hasCompletedOnboarding.value = true;
         isOnboardingActive.value = false;
         toast.success("Welcome! Start by typing a message below.");
@@ -98,7 +108,13 @@ export function Onboarding() {
 
     return (
         <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[200] flex items-center justify-center animate-fade-in">
-            <div className="w-full max-w-md bg-bg-primary border border-border rounded-2xl shadow-2xl overflow-hidden animate-scale-in">
+            <div
+                ref={panelRef}
+                role="dialog"
+                aria-modal="true"
+                aria-label="Getting started"
+                className="w-full max-w-md bg-bg-primary border border-border rounded-2xl shadow-2xl overflow-hidden animate-scale-in"
+            >
                 {/* Progress dots */}
                 <div className="flex items-center justify-center gap-2 pt-6">
                     {steps.map((_, idx) => (
@@ -123,31 +139,42 @@ export function Onboarding() {
 
                 {/* Actions */}
                 <div className="px-8 pb-8 space-y-3">
-                    {step.action ? (
+                    {step.action && (
                         <button
                             onClick={step.action}
-                            className="w-full py-3 px-4 rounded-xl bg-accent-primary text-white font-medium hover:bg-accent-primary/90 transition-colors"
+                            className="w-full py-3 px-4 rounded-xl border border-border text-text-primary font-medium hover:bg-bg-tertiary transition-colors"
                         >
                             {step.actionLabel}
                         </button>
-                    ) : (
-                        <button
-                            onClick={handleNext}
-                            className="w-full py-3 px-4 rounded-xl bg-accent-primary text-white font-medium hover:bg-accent-primary/90 transition-colors flex items-center justify-center gap-2"
-                        >
-                            {isLastStep ? "Get Started" : "Continue"}
-                            {!isLastStep && <ChevronDownIcon size={16} className="rotate-[-90deg]" />}
-                        </button>
                     )}
+                    <button
+                        onClick={handleNext}
+                        className="w-full py-3 px-4 rounded-xl bg-accent-primary text-on-accent font-medium hover:bg-accent-primary/90 transition-colors flex items-center justify-center gap-2"
+                    >
+                        {isLastStep ? "Get Started" : "Continue"}
+                        {!isLastStep && <ChevronDownIcon size={16} className="rotate-[-90deg]" />}
+                    </button>
 
-                    {!isLastStep && (
-                        <button
-                            onClick={handleSkip}
-                            className="w-full py-2 text-sm text-text-tertiary hover:text-text-primary transition-colors"
-                        >
-                            Skip intro
-                        </button>
-                    )}
+                    <div className="flex items-center justify-between pt-1">
+                        {currentStep > 0 ? (
+                            <button
+                                onClick={handleBack}
+                                className="text-sm text-text-tertiary hover:text-text-primary transition-colors"
+                            >
+                                Back
+                            </button>
+                        ) : (
+                            <span />
+                        )}
+                        {!isLastStep && (
+                            <button
+                                onClick={handleSkip}
+                                className="text-sm text-text-tertiary hover:text-text-primary transition-colors"
+                            >
+                                Skip intro
+                            </button>
+                        )}
+                    </div>
                 </div>
 
                 {/* Feature highlights for "complete" step */}

--- a/src/components/common/RagDebugPanel.tsx
+++ b/src/components/common/RagDebugPanel.tsx
@@ -141,7 +141,7 @@ export function RagDebugPanel() {
                     <button
                         onClick={handleSearch}
                         disabled={searching || !testQuery.trim()}
-                        className="px-3 py-2 bg-accent-primary text-white rounded-lg text-sm font-medium disabled:opacity-50"
+                        className="px-3 py-2 bg-accent-primary text-on-accent rounded-lg text-sm font-medium disabled:opacity-50"
                     >
                         {searching ? <SpinnerIcon size={14} className="animate-spin" /> : "Search"}
                     </button>

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -32,30 +32,14 @@ function ErrorIcon({ size = 16 }: { size?: number }) {
 function getToastStyles(type: ToastType) {
     switch (type) {
         case "success":
-            return {
-                bg: "bg-success/10 border-success/30",
-                text: "text-success",
-                icon: <CheckIcon size={16} />,
-            };
+            return { border: "border-success/40", text: "text-success", icon: <CheckIcon size={16} /> };
         case "error":
-            return {
-                bg: "bg-error/10 border-error/30",
-                text: "text-error",
-                icon: <ErrorIcon size={16} />,
-            };
+            return { border: "border-error/40", text: "text-error", icon: <ErrorIcon size={16} /> };
         case "warning":
-            return {
-                bg: "bg-warning/10 border-warning/30",
-                text: "text-warning",
-                icon: <WarningIcon size={16} />,
-            };
+            return { border: "border-warning/40", text: "text-warning", icon: <WarningIcon size={16} /> };
         case "info":
         default:
-            return {
-                bg: "bg-accent-primary/10 border-accent-primary/30",
-                text: "text-accent-primary",
-                icon: <InfoIcon size={16} />,
-            };
+            return { border: "border-accent-primary/40", text: "text-accent-primary", icon: <InfoIcon size={16} /> };
     }
 }
 
@@ -63,19 +47,32 @@ export function ToastContainer() {
     if (toasts.value.length === 0) return null;
 
     return (
-        <div className="fixed bottom-4 right-4 z-[9999] flex flex-col gap-2 pointer-events-none">
+        <div
+            className="fixed bottom-4 right-4 z-[9999] flex flex-col gap-2 pointer-events-none"
+            role="status"
+            aria-live="polite"
+        >
             {toasts.value.map((toast) => {
                 const styles = getToastStyles(toast.type);
                 return (
                     <div
                         key={toast.id}
-                        className={`pointer-events-auto flex items-center gap-3 px-4 py-3 rounded-lg border backdrop-blur-sm shadow-lg animate-toast-in ${styles.bg}`}
+                        className={`pointer-events-auto flex items-center gap-3 px-4 py-3 rounded-lg border shadow-lg animate-toast-in bg-bg-secondary ${styles.border}`}
                     >
                         <span className={styles.text}>{styles.icon}</span>
                         <span className="text-sm text-text-primary flex-1">{toast.message}</span>
+                        {toast.action && (
+                            <button
+                                onClick={() => { toast.action!.onClick(); dismissToast(toast.id); }}
+                                className={`px-2 py-1 rounded text-xs font-medium ${styles.text} hover:bg-bg-tertiary transition-colors`}
+                            >
+                                {toast.action.label}
+                            </button>
+                        )}
                         <button
                             onClick={() => dismissToast(toast.id)}
                             className="p-1 rounded hover:bg-bg-tertiary transition-colors text-text-tertiary hover:text-text-primary"
+                            aria-label="Dismiss notification"
                         >
                             <CloseIcon size={12} />
                         </button>

--- a/src/components/common/TokenCounter.tsx
+++ b/src/components/common/TokenCounter.tsx
@@ -1,4 +1,11 @@
-import { estimateTokens, currentSessionTokenCount, currentMessages } from "../../stores/appStore";
+import {
+    estimateTokens,
+    currentSessionTokenCount,
+    currentMessages,
+    contextUsageFraction,
+    activeModel,
+    getContextWindow,
+} from "../../stores/appStore";
 import { TokenIcon } from "../icons";
 
 interface TokenCounterProps {
@@ -8,6 +15,9 @@ interface TokenCounterProps {
 
 export function TokenCounter({ className = "", showDetails = false }: TokenCounterProps) {
     const totalTokens = currentSessionTokenCount.value;
+    const windowTokens = getContextWindow(activeModel.value);
+    const fraction = contextUsageFraction.value;
+    const pct = Math.min(100, Math.round(fraction * 100));
 
     // Format large numbers
     const formatTokens = (n: number): string => {
@@ -16,19 +26,20 @@ export function TokenCounter({ className = "", showDetails = false }: TokenCount
         return n.toString();
     };
 
-    // Get color based on token count (relative to common context limits)
-    const getTokenColor = (tokens: number): string => {
-        if (tokens < 8000) return "text-success";
-        if (tokens < 32000) return "text-warning";
-        return "text-error";
-    };
+    // Color + level are driven by usage relative to the active model's window,
+    // not absolute counts. The level word makes the state non-color-only.
+    const level = fraction < 0.6 ? "ok" : fraction < 0.85 ? "high" : "very-high";
+    const color = level === "ok" ? "text-success" : level === "high" ? "text-warning" : "text-error";
+    const ariaText =
+        `Context usage ${pct}% — ${formatTokens(totalTokens)} of ${formatTokens(windowTokens)} tokens` +
+        (level === "ok" ? "" : level === "high" ? ", high usage" : ", very high usage — consider a new chat");
 
     if (!showDetails) {
         return (
-            <div className={`flex items-center gap-1.5 ${className}`} title="Estimated token count">
-                <TokenIcon size={14} className={getTokenColor(totalTokens)} />
-                <span className={`text-xs ${getTokenColor(totalTokens)}`}>
-                    {formatTokens(totalTokens)}
+            <div className={`flex items-center gap-1.5 ${className}`} title={ariaText} aria-label={ariaText}>
+                <TokenIcon size={14} className={color} />
+                <span className={`text-xs ${color}`}>
+                    {pct}%
                 </span>
             </div>
         );
@@ -46,9 +57,9 @@ export function TokenCounter({ className = "", showDetails = false }: TokenCount
     return (
         <div className={`flex flex-col gap-1 ${className}`}>
             <div className="flex items-center gap-2">
-                <TokenIcon size={16} className={getTokenColor(totalTokens)} />
-                <span className={`text-sm font-medium ${getTokenColor(totalTokens)}`}>
-                    {formatTokens(totalTokens)} tokens
+                <TokenIcon size={16} className={color} />
+                <span className={`text-sm font-medium ${color}`}>
+                    {formatTokens(totalTokens)} / {formatTokens(windowTokens)} ({pct}%)
                 </span>
             </div>
             <div className="flex items-center gap-4 text-xs text-text-tertiary">

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -70,19 +70,38 @@ export function Dashboard() {
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
   const [showScrollBottom, setShowScrollBottom] = useState(false);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
+  // Whether the user is scrolled to (near) the bottom. Gates auto-scroll so
+  // streaming doesn't yank a user who has scrolled up to read history.
+  const isAtBottomRef = useRef(true);
 
   // Shared hooks - eliminates code duplication with Spotlight
   const { docsWithContent, loadingDocs, totalDocsLoaded } = useDocumentLoader();
   const { localSearchQuery, setLocalSearchQuery } = useDebouncedSearch(300);
   const { handleSubmit, regenerate, retryLast, cleanupStream } = useChatSubmit(docsWithContent, setError);
-  const handleAutoResize = useAutoResize(200);
+  const { handleAutoResize, resize } = useAutoResize(200);
+
+  // Keep the textarea height in sync with programmatic value changes (quick
+  // prompts, post-submit clear, retry) — onInput alone misses those.
+  useEffect(() => {
+    resize(inputRef.current);
+  }, [currentQuery.value, resize]);
 
   // Clean up stream listener on unmount
   useEffect(() => cleanupStream, [cleanupStream]);
 
+  // Auto-scroll on new content only when the user is already at the bottom, so
+  // streaming doesn't interrupt reading scrolled-up history.
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "instant" });
+    if (isAtBottomRef.current) {
+      messagesEndRef.current?.scrollIntoView({ behavior: "instant" });
+    }
   }, [currentMessages.value]);
+
+  // Always jump to the bottom when switching into a different conversation.
+  useEffect(() => {
+    isAtBottomRef.current = true;
+    messagesEndRef.current?.scrollIntoView({ behavior: "instant" });
+  }, [activeSessionId.value]);
 
   // Group sessions by date once per chatHistory change instead of on every
   // render. This was previously rebuilt inside the JSX IIFE on every signal
@@ -214,7 +233,7 @@ export function Dashboard() {
   return (
     <div className="h-full w-full flex bg-bg-primary">
       {/* Sidebar */}
-      <div className={`${sidebarOpen ? "w-72" : "w-0"} transition-all duration-200 overflow-hidden border-r border-border bg-bg-secondary flex flex-col`}>
+      <div className={`${sidebarOpen ? "w-72" : "w-0"} transition-[width] duration-200 ease-out overflow-hidden border-r border-border bg-bg-secondary flex flex-col`}>
         {/* Sidebar Header */}
         <div className="p-3 border-b border-border space-y-2">
           <button
@@ -552,6 +571,7 @@ export function Dashboard() {
           onScroll={(e) => {
             const el = e.target as HTMLDivElement;
             const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 100;
+            isAtBottomRef.current = atBottom;
             setShowScrollBottom(!atBottom && currentMessages.value.length > 3);
           }}
         >
@@ -649,7 +669,11 @@ export function Dashboard() {
                 );
               })()}
 
-              {currentMessages.value.map((message, index) => (
+              {currentMessages.value.map((message, index) => {
+                // Skip the empty assistant placeholder while streaming — the
+                // typing indicator stands in for it until the first chunk.
+                if (message.role === "assistant" && !message.content) return null;
+                return (
                 <div
                   key={message.id}
                   className={`group flex ${message.role === "user" ? "justify-end" : "justify-start"} animate-message-reveal`}
@@ -731,9 +755,10 @@ export function Dashboard() {
                     </div>
                   </div>
                 </div>
-              ))}
+                );
+              })}
 
-              {isGenerating.value && (
+              {isGenerating.value && !currentMessages.value[currentMessages.value.length - 1]?.content && (
                 <div className="flex justify-start">
                   <div className="bg-bg-secondary text-text-primary border border-border rounded-xl px-4 py-3">
                     <TypingIndicator className="text-accent-primary" />
@@ -748,7 +773,7 @@ export function Dashboard() {
           {/* Scroll to Bottom Button */}
           {showScrollBottom && (
             <button
-              onClick={() => messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })}
+              onClick={() => { isAtBottomRef.current = true; messagesEndRef.current?.scrollIntoView({ behavior: "smooth" }); }}
               className="absolute bottom-4 right-6 p-2 rounded-full bg-bg-secondary border border-border shadow-lg hover:bg-bg-tertiary transition-colors z-10"
               aria-label="Scroll to bottom"
               title="Scroll to bottom"

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -1,12 +1,8 @@
 import { useState, useRef, useEffect, useMemo } from "preact/hooks";
 import { invoke } from "@tauri-apps/api/core";
-import { listen, UnlistenFn } from "@tauri-apps/api/event";
 import { open } from "@tauri-apps/plugin-dialog";
 import {
   viewMode,
-  activeModel,
-  activeProvider,
-  providers,
   isGenerating,
   currentQuery,
   isSettingsOpen,
@@ -18,20 +14,17 @@ import {
   deleteChatSession,
   addDocument,
   removeDocument,
-  ChatMessage,
   ChatSession,
   Document,
-  estimateTokens,
   branchFromMessage,
-  updateBranchMessages,
-  saveChatHistoryNow,
+  loadSession,
+  startNewChat,
   searchResults,
   stopGeneration,
   isCommandPaletteOpen,
   isMaximized,
-  systemPrompt,
 } from "../../stores/appStore";
-import { useChatSubmit, parseApiError } from "../../hooks/useChatSubmit";
+import { useChatSubmit } from "../../hooks/useChatSubmit";
 import { useDocumentLoader } from "../../hooks/useDocumentLoader";
 import { useDebouncedSearch } from "../../hooks/useDebouncedSearch";
 import { useAutoResize } from "../../hooks/useAutoResize";
@@ -81,7 +74,7 @@ export function Dashboard() {
   // Shared hooks - eliminates code duplication with Spotlight
   const { docsWithContent, loadingDocs, totalDocsLoaded } = useDocumentLoader();
   const { localSearchQuery, setLocalSearchQuery } = useDebouncedSearch(300);
-  const { handleSubmit, cleanupStream } = useChatSubmit(docsWithContent, setError);
+  const { handleSubmit, regenerate, retryLast, cleanupStream } = useChatSubmit(docsWithContent, setError);
   const handleAutoResize = useAutoResize(200);
 
   // Clean up stream listener on unmount
@@ -136,27 +129,13 @@ export function Dashboard() {
   };
 
   const handleNewChat = () => {
-    currentMessages.value = [];
-    activeSessionId.value = null;
-    activeBranchId.value = null; // Reset branch state for new chat
+    startNewChat();
     setError(null);
-    currentQuery.value = "";
     inputRef.current?.focus();
   };
 
   const handleLoadSession = (session: ChatSession) => {
-    // Restore the active branch state
-    const branchId = session.activeBranchId || null;
-    activeBranchId.value = branchId;
-
-    // Load messages from the active branch or main
-    if (branchId && session.branchMessages && session.branchMessages[branchId]) {
-      currentMessages.value = session.branchMessages[branchId];
-    } else {
-      currentMessages.value = session.messages;
-    }
-
-    activeSessionId.value = session.id;
+    loadSession(session);
     setError(null);
   };
 
@@ -228,113 +207,6 @@ export function Dashboard() {
   const handleBranch = (messageId: string) => {
     if (!activeSessionId.value) return;
     branchFromMessage(activeSessionId.value, messageId);
-  };
-
-  // Regenerate: Create a branch from the user message before this assistant response.
-  // Mirrors useChatSubmit's race-safe pattern (id-based message lookup,
-  // session/branch capture) so navigating away mid-regenerate doesn't
-  // corrupt some other thread.
-  const handleRegenerate = async (assistantMessageId: string) => {
-    if (!activeSessionId.value || isGenerating.value) return;
-
-    const msgIndex = currentMessages.value.findIndex(m => m.id === assistantMessageId);
-    if (msgIndex <= 0) return;
-
-    const userMessage = currentMessages.value[msgIndex - 1];
-    if (userMessage.role !== "user") return;
-
-    const branchId = branchFromMessage(activeSessionId.value, userMessage.id);
-    if (!branchId) return;
-
-    const provider = providers.value.find(p => p.id === activeProvider.value);
-    if (!provider?.apiKey && provider?.id !== "ollama") return;
-
-    isGenerating.value = true;
-
-    const newAssistantId = crypto.randomUUID();
-    const assistantMessage: ChatMessage = {
-      id: newAssistantId,
-      role: "assistant",
-      content: "",
-      tokenCount: 0,
-    };
-    currentMessages.value = [...currentMessages.value, assistantMessage];
-
-    const submitSessionId = activeSessionId.value;
-    const submitBranchId = activeBranchId.value;
-
-    try {
-      const history = currentMessages.value.slice(0, -1).map(m => ({ role: m.role, content: m.content }));
-      const documentContext = docsWithContent
-        .filter(d => d.content && d.content.length > 0)
-        .map(d => ({ name: d.name, content: d.content! }));
-
-      let unlisten: UnlistenFn | null = null;
-      let fullResponse = "";
-      let throttleTimer: ReturnType<typeof setTimeout> | null = null;
-
-      const stillOnSameThread = () => (
-        activeSessionId.value === submitSessionId &&
-        activeBranchId.value === submitBranchId
-      );
-
-      const flushUpdate = () => {
-        throttleTimer = null;
-        if (!stillOnSameThread()) return;
-        const msgs = currentMessages.value;
-        const idx = msgs.findIndex(m => m.id === newAssistantId);
-        if (idx === -1) return;
-        const next = [...msgs];
-        next[idx] = { ...next[idx], content: fullResponse };
-        currentMessages.value = next;
-      };
-
-      unlisten = await listen<{ chunk: string; done: boolean }>("chat-stream", (event) => {
-        if (!event.payload.done) {
-          fullResponse += event.payload.chunk;
-          if (!throttleTimer) {
-            throttleTimer = setTimeout(flushUpdate, 80);
-          }
-        } else {
-          if (throttleTimer) { clearTimeout(throttleTimer); throttleTimer = null; }
-          if (unlisten) { unlisten(); unlisten = null; }
-
-          if (stillOnSameThread()) {
-            const msgs = currentMessages.value;
-            const idx = msgs.findIndex(m => m.id === newAssistantId);
-            if (idx !== -1) {
-              const next = [...msgs];
-              next[idx] = {
-                ...next[idx],
-                content: fullResponse,
-                tokenCount: estimateTokens(fullResponse),
-              };
-              currentMessages.value = next;
-            }
-          }
-
-          isGenerating.value = false;
-
-          if (fullResponse.trim().length > 0 && submitSessionId) {
-            updateBranchMessages(submitSessionId, submitBranchId, stillOnSameThread() ? currentMessages.value : []);
-            saveChatHistoryNow();
-          }
-        }
-      });
-
-      await invoke("send_message_stream", {
-        message: userMessage.content,
-        history: history.slice(0, -1),
-        documents: documentContext,
-        provider: activeProvider.value,
-        model: activeModel.value,
-        apiKey: provider?.apiKey || "",
-        systemPrompt: systemPrompt.value.trim() || null,
-      });
-    } catch (err: any) {
-      setError(parseApiError(err));
-      isGenerating.value = false;
-    }
   };
 
   const currentSession = chatHistory.value.find(s => s.id === activeSessionId.value);
@@ -823,7 +695,7 @@ export function Dashboard() {
                       {/* Regenerate button - only on latest assistant message */}
                       {message.role === "assistant" && index === currentMessages.value.length - 1 && !isGenerating.value && (
                         <button
-                          onClick={() => handleRegenerate(message.id)}
+                          onClick={() => regenerate(message.id)}
                           className="p-1.5 rounded min-w-[28px] min-h-[28px] flex items-center justify-center text-xs text-text-tertiary hover:text-text-primary hover:bg-bg-tertiary"
                           title="Regenerate response (creates a new branch)"
                           aria-label="Regenerate response"
@@ -885,12 +757,20 @@ export function Dashboard() {
           <div className="px-4 py-2 bg-error/10 border-t border-error/20 flex items-center justify-between gap-3" role="alert">
             <p className="text-sm text-error flex-1">{error}</p>
             <div className="flex items-center gap-1.5 flex-shrink-0">
-              {/Settings|API key/i.test(error) && (
+              {/Settings|API key/i.test(error) ? (
                 <button
                   onClick={() => (isSettingsOpen.value = true)}
                   className="px-2.5 py-1 rounded text-xs bg-error/20 text-error hover:bg-error/30 transition-colors"
                 >
                   Open Settings
+                </button>
+              ) : (
+                <button
+                  onClick={() => retryLast()}
+                  disabled={isGenerating.value}
+                  className="px-2.5 py-1 rounded text-xs bg-error/20 text-error hover:bg-error/30 transition-colors disabled:opacity-50"
+                >
+                  Try again
                 </button>
               )}
               <button

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -219,7 +219,7 @@ export function Dashboard() {
         <div className="p-3 border-b border-border space-y-2">
           <button
             onClick={handleNewChat}
-            className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-accent-primary text-white text-sm hover:bg-accent-primary/90 transition-colors"
+            className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-accent-primary text-on-accent text-sm hover:bg-accent-primary/90 transition-colors"
             title="New Chat (Ctrl+N)"
           >
             <PlusIcon size={16} />
@@ -324,11 +324,17 @@ export function Dashboard() {
                               onDragEnd={(e) => {
                                 (e.target as HTMLElement).style.opacity = "1";
                               }}
-                              className={`group flex items-center justify-between px-2 py-2 rounded-lg cursor-grab transition-colors ${activeSessionId.value === session.id
+                              role="button"
+                              tabIndex={0}
+                              aria-label={`Open chat ${session.title}`}
+                              className={`group flex items-center justify-between px-2 py-2 rounded-lg cursor-grab transition-colors outline-none focus-visible:ring-2 focus-visible:ring-accent-primary ${activeSessionId.value === session.id
                                 ? "bg-accent-primary/10 text-accent-primary"
                                 : "hover:bg-bg-tertiary text-text-primary"
                                 }`}
                               onClick={() => handleLoadSession(session)}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleLoadSession(session); }
+                              }}
                             >
                               <span className="text-sm truncate flex-1">{session.title}</span>
                               {/* Branch count badge */}
@@ -604,7 +610,7 @@ export function Dashboard() {
                   {totalDocsLoaded === 0 && (
                     <button
                       onClick={handleAddDocuments}
-                      className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg bg-accent-primary text-white hover:bg-accent-primary/90 transition-colors text-sm font-medium shadow-lg shadow-accent-primary/20"
+                      className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg bg-accent-primary text-on-accent hover:bg-accent-primary/90 transition-colors text-sm font-medium shadow-lg shadow-accent-primary/20"
                     >
                       <FolderIcon size={16} />
                       Add Documents
@@ -651,7 +657,7 @@ export function Dashboard() {
                 >
                   <div
                     className={`max-w-[80%] rounded-xl px-4 py-3 relative ${message.role === "user"
-                      ? "bg-accent-primary text-white"
+                      ? "bg-accent-primary text-on-accent"
                       : "bg-bg-secondary text-text-primary border border-border"
                       }`}
                   >
@@ -683,7 +689,7 @@ export function Dashboard() {
                       <button
                         onClick={() => handleCopyMessage(message.content, message.id)}
                         className={`p-1.5 rounded min-w-[28px] min-h-[28px] flex items-center justify-center text-xs ${message.role === "user"
-                          ? "text-white/70 hover:text-white hover:bg-white/10"
+                          ? "text-on-accent opacity-70 hover:opacity-100 hover:bg-black/10"
                           : "text-text-tertiary hover:text-text-primary hover:bg-bg-tertiary"
                           }`}
                         title={copiedMessageId === message.id ? "Copied!" : "Copy message"}
@@ -717,7 +723,7 @@ export function Dashboard() {
                       )}
 
                       {message.tokenCount && message.tokenCount > 10 && (
-                        <span className={`text-xs px-1 opacity-0 group-hover:opacity-100 transition-opacity ${message.role === "user" ? "text-white/50" : "text-text-tertiary/60"
+                        <span className={`text-xs px-1 opacity-0 group-hover:opacity-100 transition-opacity ${message.role === "user" ? "text-on-accent" : "text-text-tertiary/60"
                           }`}>
                           ~{message.tokenCount} tokens
                         </span>
@@ -818,7 +824,7 @@ export function Dashboard() {
                   onClick={handleSubmit}
                   disabled={!currentQuery.value.trim()}
                   className={`p-2 rounded-lg transition-all flex-shrink-0 ${currentQuery.value.trim()
-                    ? "bg-accent-primary text-white hover:bg-accent-primary/90"
+                    ? "bg-accent-primary text-on-accent hover:bg-accent-primary/90"
                     : "bg-bg-tertiary text-text-tertiary cursor-not-allowed"
                     }`}
                   title={currentQuery.value.trim() ? "Send (Enter)" : "Type a message to send"}

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -12,6 +12,7 @@ import {
   activeBranchId,
   currentMessages,
   deleteChatSession,
+  addChatSession,
   addDocument,
   removeDocument,
   ChatSession,
@@ -19,12 +20,16 @@ import {
   branchFromMessage,
   loadSession,
   startNewChat,
+  updateSessionTitle,
+  toggleSessionPinned,
   searchResults,
   stopGeneration,
   isCommandPaletteOpen,
   isMaximized,
+  isOnline,
 } from "../../stores/appStore";
 import { useChatSubmit } from "../../hooks/useChatSubmit";
+import { toast } from "../../stores/toastStore";
 import { useDocumentLoader } from "../../hooks/useDocumentLoader";
 import { useDebouncedSearch } from "../../hooks/useDebouncedSearch";
 import { useAutoResize } from "../../hooks/useAutoResize";
@@ -47,6 +52,8 @@ import {
   DownloadIcon,
   CommandIcon,
   RegenerateIcon,
+  PinIcon,
+  EditIcon,
 } from "../icons";
 import { BranchSelector } from "../common/BranchSelector";
 import { Markdown } from "../common/Markdown";
@@ -68,6 +75,8 @@ export function Dashboard() {
   const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
   const [showIndexPanel, setShowIndexPanel] = useState(false);
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameDraft, setRenameDraft] = useState("");
   const [showScrollBottom, setShowScrollBottom] = useState(false);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   // Whether the user is scrolled to (near) the bottom. Gates auto-scroll so
@@ -120,7 +129,12 @@ export function Dashboard() {
       return new Date(dateStr).toLocaleDateString("en-US", { month: "short", day: "numeric" });
     };
 
+    const pinned: typeof chatHistory.value = [];
     const grouped = chatHistory.value.reduce((acc, session) => {
+      if (session.isPinned) {
+        pinned.push(session);
+        return acc;
+      }
       const group = getDateGroup(session.createdAt);
       if (!acc[group]) acc[group] = [];
       acc[group].push(session);
@@ -137,7 +151,7 @@ export function Dashboard() {
       return 0;
     });
 
-    return { grouped, sortedGroups };
+    return { grouped, sortedGroups, pinned };
   }, [chatHistory.value]);
 
   const handleKeyDown = (e: KeyboardEvent) => {
@@ -160,13 +174,18 @@ export function Dashboard() {
 
   const handleDeleteSession = (sessionId: string) => {
     if (deleteConfirmId === sessionId) {
-      // Second click confirms deletion
+      // Second click confirms deletion. Capture the session first so the toast
+      // can offer Undo.
+      const deleted = chatHistory.value.find(s => s.id === sessionId);
       deleteChatSession(sessionId);
       if (activeSessionId.value === sessionId) {
         currentMessages.value = [];
         activeSessionId.value = null;
       }
       setDeleteConfirmId(null);
+      if (deleted) {
+        toast.action("Chat deleted", { label: "Undo", onClick: () => addChatSession(deleted) }, "info");
+      }
     } else {
       // First click shows confirmation
       setDeleteConfirmId(sessionId);
@@ -227,6 +246,140 @@ export function Dashboard() {
     if (!activeSessionId.value) return;
     branchFromMessage(activeSessionId.value, messageId);
   };
+
+  const startRename = (session: ChatSession) => {
+    setRenamingId(session.id);
+    setRenameDraft(session.title);
+  };
+
+  const commitRename = () => {
+    if (renamingId && renameDraft.trim()) {
+      updateSessionTitle(renamingId, renameDraft);
+    }
+    setRenamingId(null);
+    setRenameDraft("");
+  };
+
+  // Edit a sent user message and re-ask. Preserves the original turns as a
+  // branch (when in a saved session), then drops the user message back into the
+  // composer so the user can revise and resend from that point.
+  const handleEditMessage = (messageId: string) => {
+    if (isGenerating.value) return;
+    const idx = currentMessages.value.findIndex(m => m.id === messageId);
+    if (idx < 0) return;
+    const text = currentMessages.value[idx].content;
+
+    if (activeSessionId.value && idx > 0) {
+      // Branch from the message just before this one; the new branch ends right
+      // before the user message we're editing.
+      const branchId = branchFromMessage(activeSessionId.value, currentMessages.value[idx - 1].id);
+      if (branchId) {
+        currentMessages.value = currentMessages.value.slice(0, idx);
+      } else {
+        currentMessages.value = currentMessages.value.slice(0, idx);
+      }
+    } else {
+      // First message or unsaved chat: just truncate to before it.
+      currentMessages.value = currentMessages.value.slice(0, idx);
+    }
+    currentQuery.value = text;
+    setError(null);
+    inputRef.current?.focus();
+  };
+
+  const renderSessionRow = (session: ChatSession) => (
+    <div
+      key={session.id}
+      draggable
+      onDragStart={(e) => {
+        e.dataTransfer?.setData("text/plain", session.id);
+        (e.target as HTMLElement).style.opacity = "0.5";
+      }}
+      onDragEnd={(e) => { (e.target as HTMLElement).style.opacity = "1"; }}
+      role="button"
+      tabIndex={0}
+      aria-label={`Open chat ${session.title}`}
+      className={`group flex items-center gap-1 px-2 py-2 rounded-lg cursor-grab transition-colors outline-none focus-visible:ring-2 focus-visible:ring-accent-primary ${activeSessionId.value === session.id
+        ? "bg-accent-primary/10 text-accent-primary"
+        : "hover:bg-bg-tertiary text-text-primary"
+        }`}
+      onClick={() => handleLoadSession(session)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleLoadSession(session); }
+      }}
+    >
+      {renamingId === session.id ? (
+        <input
+          value={renameDraft}
+          onInput={(e) => setRenameDraft((e.target as HTMLInputElement).value)}
+          onKeyDown={(e) => {
+            e.stopPropagation();
+            if (e.key === "Enter") commitRename();
+            if (e.key === "Escape") { setRenamingId(null); setRenameDraft(""); }
+          }}
+          onBlur={commitRename}
+          onClick={(e) => e.stopPropagation()}
+          autoFocus
+          aria-label="Rename chat"
+          className="flex-1 min-w-0 bg-bg-primary border border-accent-primary rounded px-1 py-0.5 text-sm text-text-primary outline-none"
+        />
+      ) : (
+        <span
+          className="text-sm truncate flex-1"
+          onDblClick={(e) => { e.stopPropagation(); startRename(session); }}
+        >
+          {session.title}
+        </span>
+      )}
+
+      {session.branches.length > 0 && renamingId !== session.id && (
+        <span className="flex items-center gap-0.5 text-[10px] text-text-tertiary bg-bg-tertiary px-1.5 py-0.5 rounded-full flex-shrink-0">
+          <BranchIcon size={8} />
+          {session.branches.length + 1}
+        </span>
+      )}
+
+      {renamingId !== session.id && (
+        <div className="flex items-center flex-shrink-0">
+          <button
+            onClick={(e) => { e.stopPropagation(); toggleSessionPinned(session.id); }}
+            className={`p-1 rounded min-w-[24px] min-h-[24px] flex items-center justify-center transition-all ${session.isPinned
+              ? "opacity-100 text-accent-primary"
+              : "opacity-0 group-hover:opacity-100 text-text-tertiary hover:text-text-primary"
+              }`}
+            aria-label={session.isPinned ? "Unpin chat" : "Pin chat"}
+            aria-pressed={!!session.isPinned}
+            title={session.isPinned ? "Unpin" : "Pin"}
+          >
+            <PinIcon size={12} />
+          </button>
+          <button
+            onClick={(e) => { e.stopPropagation(); startRename(session); }}
+            className="p-1 rounded min-w-[24px] min-h-[24px] flex items-center justify-center opacity-0 group-hover:opacity-100 text-text-tertiary hover:text-text-primary transition-all"
+            aria-label="Rename chat"
+            title="Rename"
+          >
+            <EditIcon size={12} />
+          </button>
+          <button
+            onClick={(e) => { e.stopPropagation(); handleDeleteSession(session.id); }}
+            className={`p-1 rounded min-w-[24px] min-h-[24px] flex items-center justify-center transition-all ${deleteConfirmId === session.id
+              ? "opacity-100 bg-error/20 text-error"
+              : "opacity-0 group-hover:opacity-100 hover:bg-error/20 hover:text-error"
+              }`}
+            aria-label={deleteConfirmId === session.id ? "Click again to confirm delete" : "Delete chat"}
+            title={deleteConfirmId === session.id ? "Click to confirm" : "Delete"}
+          >
+            {deleteConfirmId === session.id ? (
+              <span className="text-[10px] font-medium">?</span>
+            ) : (
+              <CloseIcon size={12} />
+            )}
+          </button>
+        </div>
+      )}
+    </div>
+  );
 
   const currentSession = chatHistory.value.find(s => s.id === activeSessionId.value);
 
@@ -328,62 +481,28 @@ export function Dashboard() {
                         <div className="text-xs text-text-tertiary">No conversations yet</div>
                         <div className="text-[10px] text-text-tertiary">Start chatting to see your history here</div>
                       </div>
-                    ) : groupedSessions.sortedGroups.map(group => (
-                      <div key={group}>
-                        <div className="text-xs text-text-tertiary px-2 py-1 uppercase tracking-wide">{group}</div>
-                        <div className="space-y-0.5">
-                          {groupedSessions.grouped[group].map(session => (
-                            <div
-                              key={session.id}
-                              draggable
-                              onDragStart={(e) => {
-                                e.dataTransfer?.setData("text/plain", session.id);
-                                (e.target as HTMLElement).style.opacity = "0.5";
-                              }}
-                              onDragEnd={(e) => {
-                                (e.target as HTMLElement).style.opacity = "1";
-                              }}
-                              role="button"
-                              tabIndex={0}
-                              aria-label={`Open chat ${session.title}`}
-                              className={`group flex items-center justify-between px-2 py-2 rounded-lg cursor-grab transition-colors outline-none focus-visible:ring-2 focus-visible:ring-accent-primary ${activeSessionId.value === session.id
-                                ? "bg-accent-primary/10 text-accent-primary"
-                                : "hover:bg-bg-tertiary text-text-primary"
-                                }`}
-                              onClick={() => handleLoadSession(session)}
-                              onKeyDown={(e) => {
-                                if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleLoadSession(session); }
-                              }}
-                            >
-                              <span className="text-sm truncate flex-1">{session.title}</span>
-                              {/* Branch count badge */}
-                              {session.branches.length > 0 && (
-                                <span className="flex items-center gap-0.5 text-[10px] text-text-tertiary bg-bg-tertiary px-1.5 py-0.5 rounded-full">
-                                  <BranchIcon size={8} />
-                                  {session.branches.length + 1}
-                                </span>
-                              )}
-                              <button
-                                onClick={(e) => { e.stopPropagation(); handleDeleteSession(session.id); }}
-                                className={`p-1 rounded transition-all min-w-[24px] min-h-[24px] flex items-center justify-center ${
-                                  deleteConfirmId === session.id
-                                    ? "opacity-100 bg-error/20 text-error"
-                                    : "opacity-0 group-hover:opacity-100 hover:bg-error/20 hover:text-error"
-                                }`}
-                                aria-label={deleteConfirmId === session.id ? "Click again to confirm delete" : "Delete chat"}
-                                title={deleteConfirmId === session.id ? "Click to confirm" : "Delete"}
-                              >
-                                {deleteConfirmId === session.id ? (
-                                  <span className="text-[10px] font-medium">?</span>
-                                ) : (
-                                  <CloseIcon size={12} />
-                                )}
-                              </button>
+                    ) : (
+                      <>
+                        {groupedSessions.pinned.length > 0 && (
+                          <div>
+                            <div className="flex items-center gap-1 text-xs text-text-tertiary px-2 py-1 uppercase tracking-wide">
+                              <PinIcon size={10} /> Pinned
                             </div>
-                          ))}
-                        </div>
-                      </div>
-                    ))}
+                            <div className="space-y-0.5">
+                              {groupedSessions.pinned.map(renderSessionRow)}
+                            </div>
+                          </div>
+                        )}
+                        {groupedSessions.sortedGroups.map(group => (
+                          <div key={group}>
+                            <div className="text-xs text-text-tertiary px-2 py-1 uppercase tracking-wide">{group}</div>
+                            <div className="space-y-0.5">
+                              {groupedSessions.grouped[group].map(renderSessionRow)}
+                            </div>
+                          </div>
+                        ))}
+                      </>
+                  )}
                   </div>
               )}
             </>
@@ -509,6 +628,15 @@ export function Dashboard() {
                 <DocumentIcon size={14} className="text-accent-primary" />
                 <span className="text-xs text-accent-primary">{totalDocsLoaded} doc{totalDocsLoaded > 1 ? 's' : ''}</span>
               </button>
+            )}
+
+            {!isOnline.value && (
+              <span
+                className="flex items-center gap-1 px-2 py-1 rounded-lg bg-warning/15 text-warning text-xs font-medium"
+                title="No internet connection — only local Ollama models will work"
+              >
+                Offline
+              </span>
             )}
           </div>
 
@@ -721,6 +849,18 @@ export function Dashboard() {
                       >
                         {copiedMessageId === message.id ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
                       </button>
+
+                      {/* Edit & resend - user messages only */}
+                      {message.role === "user" && !isGenerating.value && (
+                        <button
+                          onClick={() => handleEditMessage(message.id)}
+                          className="p-1.5 rounded min-w-[28px] min-h-[28px] flex items-center justify-center text-xs text-on-accent opacity-70 hover:opacity-100 hover:bg-black/10"
+                          title="Edit & resend"
+                          aria-label="Edit and resend message"
+                        >
+                          <EditIcon size={12} />
+                        </button>
+                      )}
 
                       {/* Regenerate button - only on latest assistant message */}
                       {message.role === "assistant" && index === currentMessages.value.length - 1 && !isGenerating.value && (

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -31,6 +31,28 @@ export function LogoIcon({ size = 32, className = "" }: IconProps) {
   );
 }
 
+export function PinIcon({ size = 20, className = "" }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      aria-hidden="true"
+      focusable="false"
+      viewBox="0 0 20 20"
+      fill="none"
+      className={className}
+    >
+      <path
+        d="M12.5 2.5 17.5 7.5M11 4 4 11l-1.5 4.5L7 14l7-7M9 6l5 5"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 export function SearchIcon({ size = 20, className = "" }: IconProps) {
   return (
     <svg

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -8,6 +8,8 @@ export function LogoIcon({ size = 32, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 100 100"
       fill="none"
       className={className}
@@ -34,6 +36,8 @@ export function SearchIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -61,6 +65,8 @@ export function SendIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -88,6 +94,8 @@ export function SettingsIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -115,6 +123,8 @@ export function ExpandIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -156,6 +166,8 @@ export function CloseIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -183,6 +195,8 @@ export function ClipboardIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -210,6 +224,8 @@ export function CopyIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -237,6 +253,8 @@ export function FolderIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -257,6 +275,8 @@ export function PlusIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -284,6 +304,8 @@ export function DocumentIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -332,6 +354,8 @@ export function ChevronDownIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -352,6 +376,8 @@ export function StarIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -372,6 +398,8 @@ export function RefreshIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -406,6 +434,8 @@ export function ThumbsUpIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -426,6 +456,8 @@ export function ThumbsDownIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -446,6 +478,8 @@ export function MenuIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -480,6 +514,8 @@ export function SpinnerIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={`animate-spin ${className}`}
@@ -507,6 +543,8 @@ export function CheckIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -527,6 +565,8 @@ export function AlertIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -561,6 +601,8 @@ export function KeyIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -595,6 +637,8 @@ export function EyeIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -622,6 +666,8 @@ export function EyeOffIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -660,6 +706,8 @@ export function BranchIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -708,6 +756,8 @@ export function FolderOpenIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -735,6 +785,8 @@ export function DownloadIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -769,6 +821,8 @@ export function UploadIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -803,6 +857,8 @@ export function StopIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -826,6 +882,8 @@ export function CompareIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -864,6 +922,8 @@ export function CommandIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -891,6 +951,8 @@ export function HashIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -932,6 +994,8 @@ export function ChevronRightIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -952,6 +1016,8 @@ export function ChevronLeftIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -972,6 +1038,8 @@ export function RegenerateIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -999,6 +1067,8 @@ export function TrashIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -1026,6 +1096,8 @@ export function EditIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -1046,6 +1118,8 @@ export function TokenIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}
@@ -1073,6 +1147,8 @@ export function MessageIcon({ size = 20, className = "" }: IconProps) {
     <svg
       width={size}
       height={size}
+      aria-hidden="true"
+      focusable="false"
       viewBox="0 0 20 20"
       fill="none"
       className={className}

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -291,7 +291,7 @@ function ProviderCardCompact({ provider }: { provider: any }) {
                 testResult === "success" ? "bg-success/20 text-success border border-success/30" :
                   testResult === "error" ? "bg-error/20 text-error border border-error/30" :
                     !apiKey ? "bg-bg-tertiary text-text-tertiary cursor-not-allowed" :
-                      "bg-accent-primary text-white hover:bg-accent-primary/90"
+                      "bg-accent-primary text-on-accent hover:bg-accent-primary/90"
                 }`}
             >
               {testing ? <SpinnerIcon size={12} className="mx-auto animate-spin" /> :
@@ -320,7 +320,7 @@ function ProviderCardCompact({ provider }: { provider: any }) {
           <button onClick={handleTest} disabled={testing} className={`w-full px-2 py-1.5 rounded text-xs font-medium transition-all ${testing ? "bg-bg-tertiary text-text-tertiary" :
             testResult === "success" ? "bg-success/20 text-success" :
               testResult === "error" ? "bg-error/20 text-error" :
-                "bg-accent-primary text-white hover:bg-accent-primary/90"
+                "bg-accent-primary text-on-accent hover:bg-accent-primary/90"
             }`}>
             {testing ? "Testing..." : testResult === "success" ? "✓ Connected" : testResult === "error" ? "Connection Failed" : "Test Ollama"}
           </button>
@@ -621,7 +621,7 @@ function ProviderCard({ provider }: { provider: any }) {
                 testResult === "success" ? "bg-success/20 text-success border border-success/30" :
                   testResult === "error" ? "bg-error/20 text-error border border-error/30" :
                     !apiKey ? "bg-bg-tertiary text-text-tertiary cursor-not-allowed" :
-                      "bg-accent-primary text-white hover:bg-accent-primary/90"
+                      "bg-accent-primary text-on-accent hover:bg-accent-primary/90"
                 }`}
             >
               {testing ? (
@@ -666,7 +666,7 @@ function ProviderCard({ provider }: { provider: any }) {
             className={`w-full px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${testing ? "bg-bg-tertiary text-text-tertiary" :
               testResult === "success" ? "bg-success/20 text-success" :
                 testResult === "error" ? "bg-error/20 text-error" :
-                  "bg-accent-primary text-white hover:bg-accent-primary/90"
+                  "bg-accent-primary text-on-accent hover:bg-accent-primary/90"
               }`}
           >
             {testing ? "Testing..." : testResult === "success" ? "✓ Connected" : testResult === "error" ? "Connection Failed" : "Test Connection"}
@@ -931,7 +931,7 @@ function BehaviorTab({ compact = false }: { compact?: boolean }) {
               className={`px-3 py-1 rounded font-medium transition-colors ${
                 !isDirty || tooLong
                   ? "bg-bg-tertiary text-text-tertiary cursor-not-allowed"
-                  : "bg-accent-primary text-white hover:bg-accent-primary/90"
+                  : "bg-accent-primary text-on-accent hover:bg-accent-primary/90"
               }`}
             >
               Save
@@ -1015,7 +1015,7 @@ function PrivacyTab({ compact = false }: { compact?: boolean }) {
           className={`mt-2 w-full px-3 py-2 rounded-lg font-medium transition-colors ${
             chatHistory.value.length === 0
               ? "bg-bg-tertiary text-text-tertiary cursor-not-allowed"
-              : "bg-accent-primary text-white hover:bg-accent-primary/90"
+              : "bg-accent-primary text-on-accent hover:bg-accent-primary/90"
           } ${compact ? "text-xs py-1.5" : "text-sm"}`}
         >
           {chatHistory.value.length === 0

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -213,6 +213,7 @@ function ProviderCardCompact({ provider }: { provider: any }) {
     setTestMessage(null);
     try {
       await invoke("test_api_key", { provider: provider.id, apiKey, baseUrl: effectiveBaseUrl });
+      updateProviderApiKey(provider.id, apiKey);
       setTestResult("success");
       setTestMessage("✓ Connected!");
       setProviderConnected(provider.id, true);
@@ -269,7 +270,11 @@ function ProviderCardCompact({ provider }: { provider: any }) {
               <input
                 type={showKey ? "text" : "password"}
                 value={apiKey}
-                onInput={(e) => setApiKey((e.target as HTMLInputElement).value)}
+                onInput={(e) => {
+                  setApiKey((e.target as HTMLInputElement).value);
+                  if (testResult !== null) { setTestResult(null); setTestMessage(null); }
+                  if (provider.isConnected) setProviderConnected(provider.id, false);
+                }}
                 onBlur={handleSave}
                 placeholder="API key..."
                 aria-label={`${provider.name} API key`}
@@ -539,6 +544,9 @@ function ProviderCard({ provider }: { provider: any }) {
     setTestMessage(null);
     try {
       await invoke("test_api_key", { provider: provider.id, apiKey, baseUrl: effectiveBaseUrl });
+      // Persist the exact key that was just validated so the saved key and the
+      // verified state can't diverge.
+      updateProviderApiKey(provider.id, apiKey);
       setTestResult("success");
       setTestMessage("✓ Connection successful! API key is valid.");
       setProviderConnected(provider.id, true);
@@ -592,7 +600,12 @@ function ProviderCard({ provider }: { provider: any }) {
               <input
                 type={showKey ? "text" : "password"}
                 value={apiKey}
-                onInput={(e) => setApiKey((e.target as HTMLInputElement).value)}
+                onInput={(e) => {
+                  setApiKey((e.target as HTMLInputElement).value);
+                  // Editing the key invalidates the prior test result.
+                  if (testResult !== null) { setTestResult(null); setTestMessage(null); }
+                  if (provider.isConnected) setProviderConnected(provider.id, false);
+                }}
                 onBlur={handleSave}
                 placeholder="Enter API key..."
                 className="w-full px-3 py-2 pr-9 bg-bg-tertiary border border-border rounded-lg text-text-primary text-sm outline-none focus:border-accent-primary transition-colors"
@@ -960,8 +973,9 @@ function PrivacyTab({ compact = false }: { compact?: boolean }) {
   const handleReset = async () => {
     if (!confirmingReset) {
       setConfirmingReset(true);
-      // Auto-cancel the "are you sure" if the user wanders off.
-      setTimeout(() => setConfirmingReset(prev => prev), 5000);
+      // Auto-cancel the "are you sure" if the user wanders off. (Previously a
+      // no-op: setConfirmingReset(prev => prev) never disarmed.)
+      setTimeout(() => setConfirmingReset(false), 5000);
       return;
     }
     setResetting(true);

--- a/src/components/spotlight/Spotlight.tsx
+++ b/src/components/spotlight/Spotlight.tsx
@@ -193,7 +193,15 @@ export function Spotlight() {
         </div>
 
         {/* Messages Area */}
-        <div className="flex-1 overflow-y-auto">
+        <div
+          className="flex-1 overflow-y-auto"
+          role="log"
+          aria-live="polite"
+          aria-relevant="additions text"
+          aria-atomic="false"
+          aria-busy={isGenerating.value}
+          aria-label="Conversation"
+        >
           {currentMessages.value.length === 0 && !isGenerating.value && !error ? (
             <div className="h-full flex items-center justify-center p-4">
               <div className="text-center max-w-xs">
@@ -226,7 +234,7 @@ export function Spotlight() {
                   style={{ animationDelay: `${Math.min(index * 50, 200)}ms` }}
                 >
                   <div className={`max-w-[90%] rounded-lg px-3 py-2 text-xs relative ${msg.role === "user"
-                    ? "bg-accent-primary text-white"
+                    ? "bg-accent-primary text-on-accent"
                     : "bg-bg-tertiary text-text-primary"
                     }`}>
                     {msg.role === "user" ? (
@@ -242,7 +250,7 @@ export function Spotlight() {
                         <button
                           onClick={() => handleCopyMessage(msg.content, msg.id)}
                           className={`p-0.5 rounded ${msg.role === "user"
-                            ? "text-white/70 hover:text-white"
+                            ? "text-on-accent opacity-70 hover:opacity-100"
                             : "text-text-tertiary hover:text-text-primary"
                             }`}
                           title="Copy"
@@ -250,7 +258,7 @@ export function Spotlight() {
                           {copiedMessageId === msg.id ? <CheckIcon size={10} /> : <CopyIcon size={10} />}
                         </button>
                         {msg.tokenCount && msg.tokenCount > 10 && (
-                          <span className={`text-[10px] ${msg.role === "user" ? "text-white/50" : "text-text-tertiary/60"
+                          <span className={`text-[10px] ${msg.role === "user" ? "text-on-accent opacity-60" : "text-text-tertiary/60"
                             }`}>
                             ~{msg.tokenCount}
                           </span>
@@ -328,7 +336,7 @@ export function Spotlight() {
                 onClick={handleSubmit}
                 disabled={!currentQuery.value.trim()}
                 className={`p-2 rounded-lg transition-all flex-shrink-0 ${currentQuery.value.trim()
-                  ? "bg-accent-primary text-white hover:bg-accent-primary/90"
+                  ? "bg-accent-primary text-on-accent hover:bg-accent-primary/90"
                   : "bg-bg-tertiary text-text-tertiary cursor-not-allowed"
                   }`}
                 title={currentQuery.value.trim() ? "Send (Enter)" : "Type a message to send"}

--- a/src/components/spotlight/Spotlight.tsx
+++ b/src/components/spotlight/Spotlight.tsx
@@ -44,7 +44,12 @@ export function Spotlight() {
   // Shared hooks - eliminates code duplication with Dashboard
   const { docsWithContent, totalDocsLoaded } = useDocumentLoader();
   const { handleSubmit, cleanupStream } = useChatSubmit(docsWithContent, setError);
-  const handleAutoResize = useAutoResize(60);
+  const { handleAutoResize, resize } = useAutoResize(60);
+
+  // Keep textarea height correct on programmatic value changes too.
+  useEffect(() => {
+    resize(inputRef.current);
+  }, [currentQuery.value, resize]);
 
   // Clean up stream listener on unmount
   useEffect(() => cleanupStream, [cleanupStream]);
@@ -227,7 +232,9 @@ export function Spotlight() {
             </div>
           ) : (
             <div className="p-3 space-y-3">
-              {currentMessages.value.map((msg, index) => (
+              {currentMessages.value.map((msg, index) => {
+                if (msg.role === "assistant" && !msg.content) return null;
+                return (
                 <div
                   key={msg.id}
                   className={`group flex ${msg.role === "user" ? "justify-end" : "justify-start"} animate-message-reveal`}
@@ -267,8 +274,9 @@ export function Spotlight() {
                     )}
                   </div>
                 </div>
-              ))}
-              {isGenerating.value && (
+                );
+              })}
+              {isGenerating.value && !currentMessages.value[currentMessages.value.length - 1]?.content && (
                 <div className="flex justify-start">
                   <div className="bg-bg-tertiary rounded-lg px-3 py-2.5">
                     <TypingIndicator className="text-accent-primary" />

--- a/src/components/spotlight/Spotlight.tsx
+++ b/src/components/spotlight/Spotlight.tsx
@@ -11,6 +11,7 @@ import {
   addDocument,
   Document,
   stopGeneration,
+  startNewChat,
   isCommandPaletteOpen,
 } from "../../stores/appStore";
 import { useChatSubmit } from "../../hooks/useChatSubmit";
@@ -43,7 +44,7 @@ export function Spotlight() {
 
   // Shared hooks - eliminates code duplication with Dashboard
   const { docsWithContent, totalDocsLoaded } = useDocumentLoader();
-  const { handleSubmit, cleanupStream } = useChatSubmit(docsWithContent, setError);
+  const { handleSubmit, regenerate, cleanupStream } = useChatSubmit(docsWithContent, setError);
   const { handleAutoResize, resize } = useAutoResize(60);
 
   // Keep textarea height correct on programmatic value changes too.
@@ -88,9 +89,9 @@ export function Spotlight() {
   };
 
   const handleClear = () => {
-    currentQuery.value = "";
-    currentMessages.value = [];
-    activeSessionId.value = null;
+    // startNewChat also resets the active branch (handleClear used to leave it
+    // stale, which could write into a non-existent branch on the next send).
+    startNewChat();
     setError(null);
     inputRef.current?.focus();
   };
@@ -223,6 +224,19 @@ export function Spotlight() {
                     ? "Ask questions about your documents"
                     : "Chat, analyze, or add documents for RAG"}
                 </p>
+                {totalDocsLoaded === 0 && (
+                  <div className="flex flex-wrap items-center justify-center gap-1.5 mb-3">
+                    {["Summarize this", "Explain simply", "Brainstorm ideas"].map((q) => (
+                      <button
+                        key={q}
+                        onClick={() => { currentQuery.value = q; inputRef.current?.focus(); }}
+                        className="px-2 py-1 rounded-md border border-border text-[11px] text-text-secondary hover:bg-bg-tertiary hover:text-text-primary transition-colors"
+                      >
+                        {q}
+                      </button>
+                    ))}
+                  </div>
+                )}
                 <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-[10px] text-text-tertiary">
                   <span><kbd className="px-1 py-0.5 bg-bg-tertiary rounded border border-border">Enter</kbd> send</span>
                   <span><kbd className="px-1 py-0.5 bg-bg-tertiary rounded border border-border">Ctrl+K</kbd> commands</span>
@@ -264,6 +278,16 @@ export function Spotlight() {
                         >
                           {copiedMessageId === msg.id ? <CheckIcon size={10} /> : <CopyIcon size={10} />}
                         </button>
+                        {msg.role === "assistant" && index === currentMessages.value.length - 1 && !isGenerating.value && activeSessionId.value && (
+                          <button
+                            onClick={() => regenerate(msg.id)}
+                            className="p-0.5 rounded text-text-tertiary hover:text-text-primary"
+                            title="Regenerate response"
+                            aria-label="Regenerate response"
+                          >
+                            <RefreshIcon size={10} />
+                          </button>
+                        )}
                         {msg.tokenCount && msg.tokenCount > 10 && (
                           <span className={`text-[10px] ${msg.role === "user" ? "text-on-accent opacity-60" : "text-text-tertiary/60"
                             }`}>

--- a/src/hooks/useAutoResize.ts
+++ b/src/hooks/useAutoResize.ts
@@ -1,12 +1,18 @@
 import { useCallback } from "preact/hooks";
 
 export function useAutoResize(maxHeight = 200) {
-  const handleAutoResize = useCallback((e: Event) => {
-    const textarea = e.target as HTMLTextAreaElement;
-    // Reset height to measure scrollHeight accurately
+  // Imperative resize so programmatic value changes (quick-start prompts, the
+  // post-submit clear, retry) keep the textarea height correct — not just
+  // onInput.
+  const resize = useCallback((textarea: HTMLTextAreaElement | null) => {
+    if (!textarea) return;
     textarea.style.height = "auto";
     textarea.style.height = `${Math.min(textarea.scrollHeight, maxHeight)}px`;
   }, [maxHeight]);
 
-  return handleAutoResize;
+  const handleAutoResize = useCallback((e: Event) => {
+    resize(e.target as HTMLTextAreaElement);
+  }, [resize]);
+
+  return { handleAutoResize, resize };
 }

--- a/src/hooks/useChatSubmit.ts
+++ b/src/hooks/useChatSubmit.ts
@@ -14,6 +14,9 @@ import {
   updateChatSession,
   updateBranchMessages,
   saveChatHistoryNow,
+  branchFromMessage,
+  startNewChat,
+  getSemanticContext,
   ChatMessage,
   ChatSession,
   estimateTokens,
@@ -27,6 +30,11 @@ import {
 /// dead and surface an error rather than leaving the user staring at a
 /// blinking cursor forever.
 const CHUNK_IDLE_TIMEOUT_MS = 60_000;
+
+/// Below this combined document size we just send the full text; above it we
+/// switch to semantic retrieval (top-k relevant chunks) so large corpora don't
+/// blow the model's context window.
+const FULL_DOC_CONTEXT_THRESHOLD = 12_000;
 
 interface DocumentWithContent {
   name: string;
@@ -57,9 +65,7 @@ function handleSlashCommand(input: string, setError: (e: string | null) => void)
   switch (cmd) {
     case "/clear":
     case "/new": {
-      currentMessages.value = [];
-      activeSessionId.value = null;
-      activeBranchId.value = null;
+      startNewChat();
       setError(null);
       return true;
     }
@@ -119,6 +125,42 @@ export function parseApiError(err: any): string {
   return rawMessage;
 }
 
+/// Build the document context payload for a query. For small corpora we send
+/// the full text; for large ones we ask the backend vector store for the most
+/// relevant chunks so we don't overflow the context window. Falls back to full
+/// content if semantic retrieval returns nothing (e.g. nothing indexed yet).
+async function buildDocumentContext(
+  docsWithContent: DocumentWithContent[],
+  query: string,
+): Promise<{ name: string; content: string }[]> {
+  const withContent = docsWithContent.filter(d => d.content && d.content.length > 0);
+  if (withContent.length === 0) return [];
+
+  const totalChars = withContent.reduce((sum, d) => sum + (d.content?.length ?? 0), 0);
+  if (totalChars <= FULL_DOC_CONTEXT_THRESHOLD) {
+    return withContent.map(d => ({ name: d.name, content: d.content! }));
+  }
+
+  // Large corpus: prefer semantic retrieval.
+  try {
+    const semantic = await getSemanticContext(query);
+    if (semantic && semantic.trim().length > 0) {
+      return [{ name: "Relevant document excerpts", content: semantic }];
+    }
+  } catch {
+    // fall through to full content
+  }
+  return withContent.map(d => ({ name: d.name, content: d.content! }));
+}
+
+/// Captured context for the last send, so the error banner can offer a
+/// one-click "Try again" without the user re-typing their message.
+interface LastSend {
+  kind: "submit" | "regenerate";
+  message: string;
+  assistantMessageId?: string;
+}
+
 export function useChatSubmit(
   docsWithContent: DocumentWithContent[],
   setError: (err: string | null) => void,
@@ -127,6 +169,7 @@ export function useChatSubmit(
   const streamingContentRef = useRef("");
   const throttleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastSendRef = useRef<LastSend | null>(null);
 
   // Clean up stream listener
   const cleanupStream = useCallback(() => {
@@ -144,6 +187,115 @@ export function useChatSubmit(
     }
     streamingContentRef.current = "";
   }, []);
+
+  /// Shared streaming core used by both the initial send and regenerate.
+  /// Handles the listener, 80ms throttle, idle watchdog, race-safe flush, and
+  /// final token count. Persistence differs per caller, so it is delegated to
+  /// the onComplete callback (which receives the final content and whether the
+  /// user is still looking at the originating thread).
+  const runAssistantStream = useCallback(
+    async (params: {
+      assistantId: string;
+      submitSessionId: string | null;
+      submitBranchId: string | null;
+      message: string;
+      history: { role: string; content: string }[];
+      documents: { name: string; content: string }[];
+      apiKey: string;
+      provider?: string;
+      model?: string;
+      onComplete: (finalContent: string, sameThread: boolean) => void;
+    }) => {
+      const { assistantId, submitSessionId, submitBranchId, message, history, documents, apiKey, onComplete } = params;
+      streamingContentRef.current = "";
+
+      const stillOnSameThread = () =>
+        activeSessionId.value === submitSessionId && activeBranchId.value === submitBranchId;
+      const findAssistantIndex = (msgs: ChatMessage[]) => msgs.findIndex(m => m.id === assistantId);
+
+      const flushStreamUpdate = () => {
+        if (!stillOnSameThread()) return;
+        const msgs = currentMessages.value;
+        const idx = findAssistantIndex(msgs);
+        if (idx === -1) return;
+        const next = [...msgs];
+        next[idx] = { ...next[idx], content: streamingContentRef.current };
+        currentMessages.value = next;
+      };
+
+      const armIdleTimer = () => {
+        if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+        idleTimerRef.current = setTimeout(() => {
+          stopGeneration();
+          cleanupStream();
+          isGenerating.value = false;
+          setError("Connection stalled. The AI provider stopped responding. Please try again.");
+        }, CHUNK_IDLE_TIMEOUT_MS);
+      };
+
+      armIdleTimer();
+
+      unlistenRef.current = await listen<{ chunk: string; done: boolean }>("chat-stream", (event) => {
+        if (!event.payload.done) {
+          streamingContentRef.current += event.payload.chunk;
+          armIdleTimer();
+          if (!throttleTimerRef.current) {
+            throttleTimerRef.current = setTimeout(() => {
+              throttleTimerRef.current = null;
+              flushStreamUpdate();
+            }, 80);
+          }
+        } else {
+          if (throttleTimerRef.current) {
+            clearTimeout(throttleTimerRef.current);
+            throttleTimerRef.current = null;
+          }
+          if (idleTimerRef.current) {
+            clearTimeout(idleTimerRef.current);
+            idleTimerRef.current = null;
+          }
+
+          const finalContent = streamingContentRef.current;
+          const sameThread = stillOnSameThread();
+
+          if (sameThread) {
+            const msgs = currentMessages.value;
+            const idx = findAssistantIndex(msgs);
+            if (idx !== -1) {
+              const next = [...msgs];
+              next[idx] = {
+                ...next[idx],
+                content: finalContent,
+                tokenCount: estimateTokens(finalContent),
+              };
+              currentMessages.value = next;
+            }
+          }
+
+          isGenerating.value = false;
+          cleanupStream();
+          onComplete(finalContent, sameThread);
+        }
+      });
+
+      try {
+        await invoke("send_message_stream", {
+          message,
+          history,
+          documents,
+          provider: params.provider ?? activeProvider.value,
+          model: params.model ?? activeModel.value,
+          apiKey,
+          systemPrompt: systemPrompt.value.trim() || null,
+        });
+      } catch (err: any) {
+        setError(parseApiError(err));
+        isGenerating.value = false;
+        cleanupStream();
+      }
+    },
+    [cleanupStream, setError],
+  );
 
   const handleSubmit = useCallback(async () => {
     if (!currentQuery.value.trim() || isGenerating.value) return;
@@ -188,6 +340,7 @@ export function useChatSubmit(
     currentQuery.value = "";
     isGenerating.value = true;
     setError(null);
+    lastSendRef.current = { kind: "submit", message: query };
 
     // Create placeholder for assistant message
     const assistantId = crypto.randomUUID();
@@ -200,155 +353,174 @@ export function useChatSubmit(
     currentMessages.value = [...newMessages, assistantMessage];
 
     // Capture the session/branch context at submit time. If the user
-    // navigates away mid-stream we drop the update on the floor instead of
-    // mutating whatever they're now looking at.
+    // navigates away mid-stream we don't mutate whatever they're now looking at.
     const submitSessionId = activeSessionId.value;
     const submitBranchId = activeBranchId.value;
 
-    try {
-      const history = newMessages.slice(0, -1).map(m => ({ role: m.role, content: m.content }));
-      const documentContext = docsWithContent
-        .filter(d => d.content && d.content.length > 0)
-        .map(d => ({ name: d.name, content: d.content! }));
+    const history = newMessages.slice(0, -1).map(m => ({ role: m.role, content: m.content }));
+    const documents = await buildDocumentContext(docsWithContent, query);
 
-      streamingContentRef.current = "";
+    await runAssistantStream({
+      assistantId,
+      submitSessionId,
+      submitBranchId,
+      message: query,
+      history,
+      documents,
+      apiKey: provider?.apiKey || "",
+      onComplete: (finalContent, sameThread) => {
+        if (!submitSessionId) {
+          // First message in a fresh chat: only create a session if we
+          // actually have content. Empty stream completions (network failure,
+          // provider returns nothing) shouldn't litter the sidebar.
+          if (finalContent.trim().length > 0) {
+            const messagesToSave = sameThread
+              ? currentMessages.value
+              : [
+                  ...newMessages,
+                  { ...assistantMessage, content: finalContent, tokenCount: estimateTokens(finalContent) },
+                ];
+            const newSession: ChatSession = {
+              id: crypto.randomUUID(),
+              title: userMessage.content.slice(0, 30) + (userMessage.content.length > 30 ? "..." : ""),
+              messages: messagesToSave,
+              branches: [],
+              branchMessages: {},
+              createdAt: new Date().toISOString(),
+              folderId: null,
+            };
+            addChatSession(newSession);
+            if (sameThread) {
+              activeSessionId.value = newSession.id;
+            }
+          }
+        } else if (sameThread) {
+          if (submitBranchId) {
+            updateBranchMessages(submitSessionId, submitBranchId, currentMessages.value);
+          } else {
+            updateChatSession(submitSessionId, currentMessages.value);
+          }
+          saveChatHistoryNow();
+        } else if (finalContent.trim().length > 0) {
+          // User navigated away from an existing session mid-stream. Persist
+          // the reconstructed thread to the captured session/branch so the
+          // answer isn't lost — they may come back to it.
+          const finalMessages = [
+            ...newMessages,
+            { ...assistantMessage, content: finalContent, tokenCount: estimateTokens(finalContent) },
+          ];
+          if (submitBranchId) {
+            updateBranchMessages(submitSessionId, submitBranchId, finalMessages);
+          } else {
+            updateChatSession(submitSessionId, finalMessages);
+          }
+          saveChatHistoryNow();
+        }
+      },
+    });
+  }, [docsWithContent, setError, runAssistantStream]);
 
-      const stillOnSameThread = () => (
-        activeSessionId.value === submitSessionId &&
-        activeBranchId.value === submitBranchId
-      );
+  /// Regenerate an assistant reply. Creates a branch from the preceding user
+  /// message, then streams a fresh answer into it. Optionally overrides the
+  /// provider/model so the user can retry on a different model.
+  const regenerate = useCallback(
+    async (assistantMessageId: string, overrideProvider?: string, overrideModel?: string) => {
+      if (!activeSessionId.value || isGenerating.value) return;
 
-      // Locate the assistant message by id rather than a captured index.
-      // If a regenerate / branch / new chat shifts indices we must not
-      // overwrite the wrong message.
-      const findAssistantIndex = (msgs: ChatMessage[]) =>
-        msgs.findIndex(m => m.id === assistantId);
+      const msgs = currentMessages.value;
+      const msgIndex = msgs.findIndex(m => m.id === assistantMessageId);
+      if (msgIndex <= 0) return;
 
-      // Throttled UI update - only update DOM every 80ms during streaming
-      const flushStreamUpdate = () => {
-        if (!stillOnSameThread()) return;
-        const msgs = currentMessages.value;
-        const idx = findAssistantIndex(msgs);
-        if (idx === -1) return;
-        const next = [...msgs];
-        next[idx] = { ...next[idx], content: streamingContentRef.current };
-        currentMessages.value = next;
+      const userMessage = msgs[msgIndex - 1];
+      if (userMessage.role !== "user") return;
+
+      const providerId = overrideProvider || activeProvider.value;
+      const provider = providers.value.find(p => p.id === providerId);
+      if (!provider?.apiKey && provider?.id !== "ollama") {
+        setError(`No API key for ${provider?.name ?? providerId}. Open Settings (Ctrl+,) to add one.`);
+        return;
+      }
+
+      const sessionId = activeSessionId.value;
+      // branchFromMessage sets currentMessages to the branched copy (up to and
+      // including the user message) and activeBranchId to the new branch.
+      const branchId = branchFromMessage(sessionId, userMessage.id);
+      if (!branchId) return;
+
+      isGenerating.value = true;
+      setError(null);
+
+      const assistantId = crypto.randomUUID();
+      const assistantMessage: ChatMessage = {
+        id: assistantId,
+        role: "assistant",
+        content: "",
+        tokenCount: 0,
       };
+      const baseMessages = [...currentMessages.value, assistantMessage];
+      currentMessages.value = baseMessages;
+      lastSendRef.current = { kind: "regenerate", message: userMessage.content, assistantMessageId };
 
-      const armIdleTimer = () => {
-        if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
-        idleTimerRef.current = setTimeout(() => {
-          // No chunk in CHUNK_IDLE_TIMEOUT_MS - tell the backend to drop
-          // the connection and surface a friendly error.
-          stopGeneration();
-          cleanupStream();
-          isGenerating.value = false;
-          setError("Connection stalled. The AI provider stopped responding. Please try again.");
-        }, CHUNK_IDLE_TIMEOUT_MS);
-      };
+      const submitSessionId = sessionId;
+      const submitBranchId = branchId;
 
-      armIdleTimer();
+      // History = everything before the user message (exclude the user message
+      // itself and the just-added empty placeholder).
+      const history = baseMessages.slice(0, -2).map(m => ({ role: m.role, content: m.content }));
+      const documents = await buildDocumentContext(docsWithContent, userMessage.content);
 
-      unlistenRef.current = await listen<{ chunk: string; done: boolean }>("chat-stream", (event) => {
-        if (!event.payload.done) {
-          streamingContentRef.current += event.payload.chunk;
-          armIdleTimer();
-
-          // Throttle UI updates to every 80ms instead of every chunk
-          if (!throttleTimerRef.current) {
-            throttleTimerRef.current = setTimeout(() => {
-              throttleTimerRef.current = null;
-              flushStreamUpdate();
-            }, 80);
-          }
-        } else {
-          // Stream complete - final flush with token count
-          if (throttleTimerRef.current) {
-            clearTimeout(throttleTimerRef.current);
-            throttleTimerRef.current = null;
-          }
-          if (idleTimerRef.current) {
-            clearTimeout(idleTimerRef.current);
-            idleTimerRef.current = null;
-          }
-
-          const finalContent = streamingContentRef.current;
-          const sameThread = stillOnSameThread();
-
-          if (sameThread) {
-            const msgs = currentMessages.value;
-            const idx = findAssistantIndex(msgs);
-            if (idx !== -1) {
-              const next = [...msgs];
-              next[idx] = {
-                ...next[idx],
-                content: finalContent,
-                tokenCount: estimateTokens(finalContent),
-              };
-              currentMessages.value = next;
-            }
-          }
-
-          isGenerating.value = false;
-          cleanupStream();
-
-          // Persist regardless of whether the user is still looking at
-          // this thread — they may come back. Write to the captured
-          // session/branch, not the current one.
-          if (!submitSessionId) {
-            // First message in a fresh chat: only create a session if we
-            // actually have content. Empty stream completions (network
-            // failure, provider returns nothing) shouldn't litter the
-            // sidebar with empty conversations.
-            if (finalContent.trim().length > 0) {
-              const messagesToSave = sameThread
-                ? currentMessages.value
-                : [
-                    ...newMessages,
-                    { ...assistantMessage, content: finalContent, tokenCount: estimateTokens(finalContent) },
-                  ];
-              const newSession: ChatSession = {
-                id: crypto.randomUUID(),
-                title: userMessage.content.slice(0, 30) + (userMessage.content.length > 30 ? "..." : ""),
-                messages: messagesToSave,
-                branches: [],
-                branchMessages: {},
-                createdAt: new Date().toISOString(),
-                folderId: null,
-              };
-              addChatSession(newSession);
-              if (sameThread) {
-                activeSessionId.value = newSession.id;
-              }
-            }
-          } else if (sameThread) {
-            if (submitBranchId) {
-              updateBranchMessages(submitSessionId, submitBranchId, currentMessages.value);
-            } else {
-              updateChatSession(submitSessionId, currentMessages.value);
-            }
+      await runAssistantStream({
+        assistantId,
+        submitSessionId,
+        submitBranchId,
+        message: userMessage.content,
+        history,
+        documents,
+        apiKey: provider?.apiKey || "",
+        provider: providerId,
+        model: overrideModel || activeModel.value,
+        onComplete: (finalContent, sameThread) => {
+          if (finalContent.trim().length > 0) {
+            // Fix for the old data-loss bug: when the user has navigated away,
+            // persist the reconstructed branch messages instead of writing [].
+            const finalMessages = sameThread
+              ? currentMessages.value
+              : [
+                  ...baseMessages.slice(0, -1),
+                  { ...assistantMessage, content: finalContent, tokenCount: estimateTokens(finalContent) },
+                ];
+            updateBranchMessages(submitSessionId, submitBranchId, finalMessages);
             saveChatHistoryNow();
           }
-        }
+        },
       });
+    },
+    [docsWithContent, setError, runAssistantStream],
+  );
 
-      // Start streaming
-      await invoke("send_message_stream", {
-        message: query,
-        history,
-        documents: documentContext,
-        provider: activeProvider.value,
-        model: activeModel.value,
-        apiKey: provider?.apiKey || "",
-        systemPrompt: systemPrompt.value.trim() || null,
-      });
-
-    } catch (err: any) {
-      setError(parseApiError(err));
-      isGenerating.value = false;
-      cleanupStream();
+  /// Retry the last send after a failure. Re-runs the most recent submit
+  /// (re-using the captured user message) or regenerate, without the user
+  /// having to retype anything.
+  const retryLast = useCallback(async () => {
+    const last = lastSendRef.current;
+    if (!last || isGenerating.value) return;
+    setError(null);
+    if (last.kind === "regenerate" && last.assistantMessageId) {
+      await regenerate(last.assistantMessageId);
+      return;
     }
-  }, [docsWithContent, setError, cleanupStream]);
+    // Re-submit: drop any empty/failed trailing assistant placeholder, then
+    // re-send the captured user message.
+    const msgs = currentMessages.value;
+    const trimmed = msgs[msgs.length - 1]?.role === "assistant" && !msgs[msgs.length - 1].content
+      ? msgs.slice(0, -1)
+      : msgs;
+    // Remove the trailing user message too (handleSubmit re-adds it from currentQuery).
+    const withoutUser = trimmed[trimmed.length - 1]?.role === "user" ? trimmed.slice(0, -1) : trimmed;
+    currentMessages.value = withoutUser;
+    currentQuery.value = last.message;
+    await handleSubmit();
+  }, [regenerate, handleSubmit, setError]);
 
-  return { handleSubmit, cleanupStream };
+  return { handleSubmit, regenerate, retryLast, cleanupStream };
 }

--- a/src/hooks/useChatSubmit.ts
+++ b/src/hooks/useChatSubmit.ts
@@ -17,6 +17,7 @@ import {
   branchFromMessage,
   startNewChat,
   getSemanticContext,
+  isOnline,
   ChatMessage,
   ChatSession,
   estimateTokens,
@@ -324,6 +325,12 @@ export function useChatSubmit(
       setError(
         `No API key for ${provider?.name ?? activeProvider.value}. Open Settings (Ctrl+,) to add one.`,
       );
+      return;
+    }
+
+    // Cloud providers need connectivity; local Ollama doesn't.
+    if (!isOnline.value && provider?.id !== "ollama") {
+      setError("You're offline. Reconnect, or switch to a local Ollama model.");
       return;
     }
 

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,76 @@
+import { useEffect } from "preact/hooks";
+import { RefObject } from "preact";
+
+/// Trap keyboard focus inside a modal/overlay for accessibility:
+///   - moves focus to the first focusable element on open
+///   - cycles Tab / Shift+Tab within the container instead of escaping to the
+///     page behind the overlay
+///   - restores focus to the element that was focused before opening
+///   - optionally closes on Escape (and stops the event so a global Escape
+///     handler doesn't also fire, e.g. hiding the whole window)
+///
+/// Extracted from the proven Settings modal implementation so every overlay
+/// (CommandPalette, ModelCompare, ExportImport, KeyboardShortcuts, Onboarding)
+/// behaves consistently.
+export function useFocusTrap<T extends HTMLElement>(
+  ref: RefObject<T>,
+  active: boolean,
+  onClose?: () => void,
+) {
+  useEffect(() => {
+    if (!active) return;
+    const container = ref.current;
+    if (!container) return;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    const getFocusable = (): HTMLElement[] => {
+      const els = Array.from(
+        container.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      );
+      // Skip elements that are hidden (display:none collapses offsetParent) or
+      // explicitly hidden from the a11y tree.
+      return els.filter(
+        (el) => el.offsetParent !== null && el.getAttribute("aria-hidden") !== "true",
+      );
+    };
+
+    const focusables = getFocusable();
+    if (focusables.length > 0) focusables[0].focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && onClose) {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const els = getFocusable();
+      if (els.length === 0) return;
+      const first = els[0];
+      const last = els[els.length - 1];
+      const activeEl = document.activeElement as HTMLElement;
+      if (e.shiftKey) {
+        if (activeEl === first || !container.contains(activeEl)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (activeEl === last || !container.contains(activeEl)) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    container.addEventListener("keydown", handleKeyDown);
+    return () => {
+      container.removeEventListener("keydown", handleKeyDown);
+      // Restore focus to where the user was before the modal opened.
+      previouslyFocused?.focus?.();
+    };
+  }, [active, onClose, ref]);
+}

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -101,6 +101,40 @@ export const isFullscreen = signal(false);
 // listeners.
 export const isOnline = signal(typeof navigator !== "undefined" ? navigator.onLine : true);
 
+// True while files are being dragged over the window (drives the drop overlay).
+export const isDragOver = signal(false);
+
+// Extensions accepted via drag-drop (mirrors the file-picker filters + backend
+// allow-list).
+const DROP_ALLOWED_EXT = [
+  "pdf", "txt", "md", "rst", "html", "htm", "py", "js", "ts", "tsx", "jsx", "rs",
+  "java", "cpp", "c", "h", "hpp", "go", "rb", "php", "swift", "kt", "cs", "json",
+  "yaml", "yml", "toml", "xml", "csv", "sh", "ps1", "sql", "log", "conf", "ini",
+  "env", "docx",
+];
+
+/// Add files dropped onto the window as documents. Filters to supported
+/// extensions and de-dupes by path. Returns how many were added.
+export function addDroppedFiles(paths: string[]): number {
+  let added = 0;
+  for (const filePath of paths) {
+    const name = filePath.split(/[/\\]/).pop() || "Unknown";
+    const ext = (name.split(".").pop() || "").toLowerCase();
+    if (!DROP_ALLOWED_EXT.includes(ext)) continue;
+    if (documents.value.some(d => d.path === filePath)) continue;
+    addDocument({
+      id: crypto.randomUUID(),
+      name,
+      path: filePath,
+      size: 0,
+      type: ext,
+      addedAt: new Date().toISOString(),
+    });
+    added++;
+  }
+  return added;
+}
+
 // Keyboard Shortcuts Help
 export const isShortcutsHelpOpen = signal(false);
 

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -96,6 +96,11 @@ export const compareResponses = signal<{ model: string; content: string; isLoadi
 export const isMaximized = signal(false);
 export const isFullscreen = signal(false);
 
+// Connectivity — reflected in the header and used to short-circuit cloud sends
+// while offline (local Ollama still works). Updated by App.tsx online/offline
+// listeners.
+export const isOnline = signal(typeof navigator !== "undefined" ? navigator.onLine : true);
+
 // Keyboard Shortcuts Help
 export const isShortcutsHelpOpen = signal(false);
 
@@ -292,6 +297,35 @@ export function estimateTokens(text: string): number {
   if (!text) return 0;
   return Math.ceil(text.length / 4);
 }
+
+// Approximate context-window sizes (tokens) so the UI can show usage as a
+// fraction of the active model's window rather than an absolute count. Matched
+// by substring against the model id; falls back to a conservative default.
+const CONTEXT_WINDOWS: { match: string; tokens: number }[] = [
+  { match: "gemini-3", tokens: 1_000_000 },
+  { match: "gemini-2.5", tokens: 1_000_000 },
+  { match: "gemini", tokens: 1_000_000 },
+  { match: "gpt-4o", tokens: 128_000 },
+  { match: "gpt-4-turbo", tokens: 128_000 },
+  { match: "gpt-4", tokens: 128_000 },
+  { match: "claude", tokens: 200_000 },
+  { match: "glm-4.6", tokens: 200_000 },
+  { match: "glm-4.7", tokens: 200_000 },
+  { match: "glm", tokens: 128_000 },
+];
+const DEFAULT_CONTEXT_WINDOW = 32_000;
+
+export function getContextWindow(model: string): number {
+  const m = model.toLowerCase();
+  const hit = CONTEXT_WINDOWS.find(c => m.includes(c.match));
+  return hit ? hit.tokens : DEFAULT_CONTEXT_WINDOW;
+}
+
+// Fraction (0-1) of the active model's context window used by the current chat.
+export const contextUsageFraction = computed(() => {
+  const used = currentMessages.value.reduce((sum, msg) => sum + (msg.tokenCount || 0), 0);
+  return used / getContextWindow(activeModel.value);
+});
 
 // Search chat history
 export function searchChatHistory(query: string): SearchResult[] {
@@ -1023,27 +1057,77 @@ export function exportAllSessions(): string {
 export function importSession(jsonString: string): ChatSession | null {
   try {
     const data = JSON.parse(jsonString);
-    if (data.id && data.title && Array.isArray(data.messages)) {
-      const session: ChatSession = {
-        id: crypto.randomUUID(), // Generate new ID to avoid conflicts
-        title: data.title,
-        messages: data.messages.map((m: any) => ({
-          id: crypto.randomUUID(),
-          role: m.role,
-          content: m.content,
-          tokenCount: estimateTokens(m.content),
-        })),
-        branches: [],
-        branchMessages: {},
-        createdAt: new Date().toISOString(),
-        folderId: null,
-      };
-      addChatSession(session);
-      return session;
-    }
-    return null;
+    if (!data || !data.title || !Array.isArray(data.messages)) return null;
+    // Preserve message + branch ids so branch lineage (fromMessageId,
+    // branchMessages keys) stays intact on round-trip. Only the session id is
+    // regenerated to avoid collisions with an existing session.
+    const session: ChatSession = {
+      id: crypto.randomUUID(),
+      title: String(data.title),
+      messages: data.messages.map((m: any) => ({
+        id: m.id || crypto.randomUUID(),
+        role: m.role === "assistant" ? "assistant" : "user",
+        content: String(m.content ?? ""),
+        tokenCount: m.tokenCount ?? estimateTokens(String(m.content ?? "")),
+        parentId: m.parentId ?? null,
+        branchIndex: m.branchIndex,
+      })),
+      branches: Array.isArray(data.branches) ? data.branches : [],
+      branchMessages:
+        data.branchMessages && typeof data.branchMessages === "object" ? data.branchMessages : {},
+      createdAt: data.createdAt || new Date().toISOString(),
+      folderId: null,
+    };
+    addChatSession(session);
+    return session;
   } catch (e) {
     console.error("Failed to import session:", e);
+    return null;
+  }
+}
+
+/// Import the full backup envelope produced by exportAllSessions
+/// ({ version, sessions, folders }). Restores folders and every session,
+/// preserving ids (so folder assignments survive). Returns the number of
+/// sessions imported, or null if the JSON isn't a recognizable envelope.
+export function importAllSessions(jsonString: string): number | null {
+  try {
+    const data = JSON.parse(jsonString);
+    if (!data || !Array.isArray(data.sessions)) return null;
+
+    if (Array.isArray(data.folders)) {
+      const existingIds = new Set(chatFolders.value.map(f => f.id));
+      const incoming = data.folders.filter((f: any) => f && f.id && f.name && !existingIds.has(f.id));
+      if (incoming.length > 0) {
+        chatFolders.value = [...chatFolders.value, ...incoming];
+      }
+    }
+
+    const existingSessionIds = new Set(chatHistory.value.map(s => s.id));
+    let count = 0;
+    const restored: ChatSession[] = [];
+    for (const s of data.sessions) {
+      if (!s || !s.title || !Array.isArray(s.messages) || existingSessionIds.has(s.id)) continue;
+      restored.push({
+        id: s.id || crypto.randomUUID(),
+        title: String(s.title),
+        messages: s.messages,
+        branches: Array.isArray(s.branches) ? s.branches : [],
+        branchMessages: s.branchMessages && typeof s.branchMessages === "object" ? s.branchMessages : {},
+        createdAt: s.createdAt || new Date().toISOString(),
+        folderId: s.folderId ?? null,
+        isPinned: s.isPinned,
+      });
+      count++;
+    }
+    if (restored.length > 0) {
+      chatHistory.value = [...restored, ...chatHistory.value];
+    }
+    saveChatHistoryNow();
+    saveChatFolders();
+    return count;
+  } catch (e) {
+    console.error("Failed to import backup:", e);
     return null;
   }
 }

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -48,6 +48,7 @@ export interface ChatSession {
   createdAt: string;
   folderId?: string | null;
   activeBranchId?: string | null;
+  isPinned?: boolean;
 }
 
 export interface ChatFolder {
@@ -610,8 +611,12 @@ export async function saveDocuments() {
 
 // Actions
 export function updateProviderApiKey(providerId: string, apiKey: string) {
+  // Changing the key invalidates any prior "verified" state — the new key
+  // hasn't been tested. Keep isConnected only when the key is unchanged.
   providers.value = providers.value.map((p) =>
-    p.id === providerId ? { ...p, apiKey } : p
+    p.id === providerId
+      ? { ...p, apiKey, isConnected: p.apiKey === apiKey ? p.isConnected : false }
+      : p
   );
   saveProviders();
 }
@@ -638,6 +643,70 @@ export function updateChatSession(sessionId: string, messages: ChatMessage[]) {
 export function deleteChatSession(sessionId: string) {
   chatHistory.value = chatHistory.value.filter(s => s.id !== sessionId);
   saveChatHistoryNow(); // Immediate for destructive action
+}
+
+/// Canonical "open this conversation" action. Restores the session's active
+/// branch (and its messages) so we never leave activeBranchId pointing at a
+/// previous session's branch. Every entry point — sidebar, folders, command
+/// palette, and the App.tsx keyboard shortcuts — routes through this so branch
+/// state can't drift out of sync.
+export function loadSession(session: ChatSession) {
+  const branchId = session.activeBranchId || null;
+  if (branchId && session.branchMessages && session.branchMessages[branchId]) {
+    currentMessages.value = session.branchMessages[branchId];
+  } else {
+    currentMessages.value = session.messages;
+  }
+  activeBranchId.value = branchId;
+  activeSessionId.value = session.id;
+}
+
+/// Load a session by its position in chatHistory (Ctrl+1-9 quick nav).
+export function loadSessionByIndex(index: number): boolean {
+  const session = chatHistory.value[index];
+  if (!session) return false;
+  loadSession(session);
+  return true;
+}
+
+/// Move to the previous (-1) or next (+1) session relative to the active one.
+export function loadAdjacentSession(direction: -1 | 1): boolean {
+  if (!activeSessionId.value) return false;
+  const i = chatHistory.value.findIndex(s => s.id === activeSessionId.value);
+  if (i === -1) return false;
+  const j = i + direction;
+  if (j < 0 || j >= chatHistory.value.length) return false;
+  loadSession(chatHistory.value[j]);
+  return true;
+}
+
+/// Start a fresh, unsaved chat. Clears the working conversation AND the active
+/// branch so the next send can't write into a stale branch.
+export function startNewChat() {
+  currentMessages.value = [];
+  activeSessionId.value = null;
+  activeBranchId.value = null;
+  currentQuery.value = "";
+}
+
+/// Rename a chat session. Titles are otherwise auto-derived from the first
+/// user message; this lets the user give a conversation a meaningful name.
+export function updateSessionTitle(sessionId: string, title: string) {
+  const trimmed = title.trim();
+  if (!trimmed) return;
+  chatHistory.value = chatHistory.value.map(s =>
+    s.id === sessionId ? { ...s, title: trimmed.slice(0, 120) } : s
+  );
+  saveChatHistoryNow();
+}
+
+/// Toggle a session's pinned state. Pinned sessions surface in their own group
+/// above the date groups in the sidebar.
+export function toggleSessionPinned(sessionId: string) {
+  chatHistory.value = chatHistory.value.map(s =>
+    s.id === sessionId ? { ...s, isPinned: !s.isPinned } : s
+  );
+  saveChatHistoryNow();
 }
 
 export function updateSessionFolder(sessionId: string, folderId: string | null) {

--- a/src/stores/toastStore.ts
+++ b/src/stores/toastStore.ts
@@ -2,22 +2,51 @@ import { signal } from "@preact/signals";
 
 export type ToastType = "success" | "error" | "info" | "warning";
 
+export interface ToastAction {
+    label: string;
+    onClick: () => void;
+}
+
 export interface Toast {
     id: string;
     message: string;
     type: ToastType;
     duration?: number;
+    action?: ToastAction;
 }
 
 // Toast queue
 export const toasts = signal<Toast[]>([]);
 
-// Show a toast notification
-export function showToast(message: string, type: ToastType = "info", duration: number = 3000) {
-    const id = crypto.randomUUID();
-    const toast: Toast = { id, message, type, duration };
+// Cap the on-screen queue so a burst of errors can't stack endlessly.
+const MAX_TOASTS = 4;
 
-    toasts.value = [...toasts.value, toast];
+interface ShowToastOptions {
+    duration?: number;
+    action?: ToastAction;
+}
+
+// Show a toast notification. Identical (message+type) toasts are de-duped so a
+// repeated failure doesn't stack N copies.
+export function showToast(
+    message: string,
+    type: ToastType = "info",
+    durationOrOpts: number | ShowToastOptions = 3000,
+) {
+    const opts: ShowToastOptions =
+        typeof durationOrOpts === "number" ? { duration: durationOrOpts } : durationOrOpts;
+    const duration = opts.duration ?? 3000;
+
+    // De-dupe: if an identical toast is already showing, keep it (don't stack).
+    const existing = toasts.value.find(t => t.message === message && t.type === type && !t.action);
+    if (existing && !opts.action) return existing.id;
+
+    const id = crypto.randomUUID();
+    const toast: Toast = { id, message, type, duration, action: opts.action };
+
+    const next = [...toasts.value, toast];
+    // Drop the oldest if we exceed the cap.
+    toasts.value = next.length > MAX_TOASTS ? next.slice(next.length - MAX_TOASTS) : next;
 
     // Auto-dismiss after duration
     if (duration > 0) {
@@ -45,4 +74,7 @@ export const toast = {
     error: (message: string, duration?: number) => showToast(message, "error", duration),
     info: (message: string, duration?: number) => showToast(message, "info", duration),
     warning: (message: string, duration?: number) => showToast(message, "warning", duration),
+    /** Toast with an action button (e.g. Undo). Longer default duration. */
+    action: (message: string, action: ToastAction, type: ToastType = "info", duration = 6000) =>
+        showToast(message, type, { action, duration }),
 };

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -8,13 +8,18 @@
   --bg-tertiary: #e9ecef;
   --text-primary: #212529;
   --text-secondary: #495057;
-  --text-tertiary: #868e96;
+  /* WCAG AA: #6b7280 ≈ 4.6:1 on white (was #868e96 ≈ 3.3:1) */
+  --text-tertiary: #6b7280;
   --accent-primary: #2563eb;
   --accent-secondary: #7c3aed;
   --border-color: #dee2e6;
-  --success: #22c55e;
-  --warning: #f59e0b;
-  --error: #ef4444;
+  /* Foreground for text/icons placed on an accent fill. White passes on this
+     dark-blue accent; light themes with bright accents use dark on-accent. */
+  --on-accent: #ffffff;
+  /* AA-legible semantic colors for use as foreground text on a light bg. */
+  --success: #15803d;
+  --warning: #b45309;
+  --error: #b91c1c;
   --glass-bg: rgba(255, 255, 255, 0.92);
   --code-block-bg: #1e293b;
   --code-text: #e2e8f0;
@@ -26,10 +31,19 @@
   --bg-tertiary: #252529;
   --text-primary: #ffffff;
   --text-secondary: #a0a0a8;
-  --text-tertiary: #6b6b73;
+  /* WCAG AA: #8a8a93 ≈ 5.1:1 on #0d0d0f (was #6b6b73 ≈ 3.7:1) */
+  --text-tertiary: #8a8a93;
   --accent-primary: #4a9eff;
   --accent-secondary: #7c3aed;
   --border-color: #2e2e35;
+  /* Bright accent → dark on-accent text for legible chat bubbles / buttons. */
+  --on-accent: #07203a;
+  /* Bright semantic colors are legible on the dark bg; defined here (not just
+     in :root) so the dark-family themes don't inherit the light theme's dark
+     semantic colors. .transparent inherits these. */
+  --success: #22c55e;
+  --warning: #f59e0b;
+  --error: #ef4444;
   --glass-bg: rgba(13, 13, 15, 0.92);
   --code-block-bg: #1a1a2e;
   --code-text: #d4d4d8;
@@ -42,10 +56,11 @@
   --bg-tertiary: rgba(37, 37, 41, 0.5);
   --text-primary: #ffffff;
   --text-secondary: #b0b0b8;
-  --text-tertiary: #7b7b83;
+  --text-tertiary: #8e8e96;
   --accent-primary: #5aafff;
   --accent-secondary: #9c5aff;
   --border-color: rgba(255, 255, 255, 0.08);
+  --on-accent: #06203a;
   --glass-bg: rgba(10, 10, 12, 0.7);
   --code-block-bg: rgba(15, 15, 25, 0.8);
   --code-text: #d4d4d8;
@@ -58,13 +73,17 @@
   --bg-tertiary: #ece8e1;
   --text-primary: #1a1a1a;
   --text-secondary: #4a4a4a;
-  --text-tertiary: #7a7a7a;
+  /* WCAG AA: #6b6b6b ≈ 4.7:1 on the cream bg (was #7a7a7a ≈ 4.0:1) */
+  --text-tertiary: #6b6b6b;
   --accent-primary: #e85a6b;
   --accent-secondary: #d14d5c;
   --border-color: #e0dbd4;
-  --success: #10b981;
-  --warning: #f59e0b;
-  --error: #ef4444;
+  /* Coral accent fails white; use dark on-accent text. */
+  --on-accent: #2e0a0f;
+  /* AA-legible semantic colors on the cream background. */
+  --success: #15803d;
+  --warning: #b45309;
+  --error: #b91c1c;
   --glass-bg: rgba(250, 248, 245, 0.95);
   --code-block-bg: #2d2a2e;
   --code-text: #e3e1e8;
@@ -209,9 +228,33 @@ a:focus-visible,
   border-radius: 4px;
 }
 
+/* Foreground for content sitting on an accent-colored fill (chat bubbles,
+   primary buttons). Chosen per-theme so it always meets WCAG AA contrast,
+   without recoloring the accent itself. */
+.text-on-accent {
+  color: var(--on-accent);
+}
+
 /* Active press feedback */
 button:active {
   transform: scale(0.98);
+}
+
+/* Honor the OS "reduce motion" preference: neutralize entrance animations,
+   infinite loops (typing dots, shimmer, spinners), and the press scale. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  button:active {
+    transform: none;
+  }
 }
 
 .glass {
@@ -349,23 +392,6 @@ button:active {
 .markdown-content h2:first-child,
 .markdown-content h3:first-child {
   margin-top: 0;
-}
-
-/* Sticky copy button inside code blocks */
-.code-block-pre {
-  position: relative;
-}
-
-.sticky-copy-btn {
-  position: sticky;
-  bottom: 8px;
-  float: right;
-  margin-top: -20px;
-  background: rgba(26, 26, 46, 0.95);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  border: 1px solid var(--border-color);
-  z-index: 10;
 }
 
 /* Scale-in animation for modals and command palette */


### PR DESCRIPTION
Acts on a fresh, verified review of the app (the in-repo `*_ANALYSIS.md` docs were stale — most of their backlog was already fixed). 6 commits, each builds green (`tsc + vite` and `cargo check`).

## 🔴 Correctness (P0)
- **Fix data-loss**: regenerate no longer writes `[]` over a branch when you navigate away mid-stream; regenerate now lives in the shared stream core so it inherits the 60s idle watchdog + listener cleanup it was missing.
- **Branch-state desync**: canonical branch-aware `loadSession` / `startNewChat` / quick-nav helpers; App.tsx shortcuts, CommandPalette, Dashboard and FolderManager all route through them, so `activeBranchId` can no longer go stale and corrupt a thread.
- Stale "verified" API-key badge cleared on edit; tested key is persisted. No-op reset auto-cancel timer fixed. Persistent **Try again** on the error banner.
- **RAG retrieval is now wired** into sends (`buildDocumentContext` → semantic top-k above a size threshold; full text below), and the backend now indexes the **full** document text instead of the 100k display cap.

## ♿ Accessibility
- Per-theme `--on-accent` token + `--text-tertiary` + semantic colors → **WCAG AA in all 6 themes** (user bubbles, CTAs, tertiary text).
- Global `prefers-reduced-motion`. Reusable `useFocusTrap` + `role="dialog"`/`aria-modal` on all 5 modals. **Spotlight `aria-live`** (was silent to screen readers). Decorative SVGs `aria-hidden`. BranchSelector + sidebar/folder rows keyboard-operable. Icon-button labels.

## ✨ Smoothness
- Auto-scroll only when at bottom (no more yanking while reading history); removed the double-bubble flash on send; textarea height re-syncs on programmatic changes.
- Opaque toasts + **Undo** action + queue cap/dedupe; dropdown Escape + scroll-active-into-view.

## 🧩 Features
- Pin chats (Pinned group), inline rename, **edit & resend** (branch-preserving), delete **Undo**.
- **Context-window %** usage meter (model-aware, with a non-color-only level word).
- **Offline** indicator + cloud-send guard (local Ollama still works).
- **Drag files onto the window** to add documents (fulfills the onboarding promise) + drop overlay.
- Import via **file picker** + full backup round-trip; import preserves branches. Onboarding api-key step no longer dead-ends.

## ⚙️ Backend resilience
- `spawn_blocking` PDF parse (no longer stalls the async runtime).
- **SSE streaming + cancellation for OpenAI & Ollama** (were buffered). Gemini/GLM already streamed; **Anthropic intentionally kept on the buffered fallback**.
- HTTP status → specific errors (429 → RateLimited, 401/403 → InvalidApiKey) + timeout/connect detection. Vector store opens with **WAL + busy_timeout**.

## Deferred (intentionally, noted for follow-up)
Not done to avoid regressing working behavior without a runtime GUI pass: API keys → OS keychain, Anthropic SSE, per-request `streamId`, regenerate-with-a-different-model picker UI, message virtualization, batch embeddings.

## Testing
Build-verified only (`tsc + vite` green, `cargo check` green at every step). **Not yet runtime-tested in the Tauri GUI** — recommend a local `npm run tauri dev` pass over the streaming, drag-drop, and edit/regenerate flows before merge.